### PR TITLE
Script to add missing users to all deployed p4 websites

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -276,3 +276,6 @@ deploy-helm:
 
 	HELM_RELEASE=$(HELM_RELEASE) \
 	./newrelic_deployment.sh
+
+	HELM_RELEASE=$(HELM_RELEASE) \
+	./run_bash_script_in_php_pod.sh ls.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -277,5 +277,6 @@ deploy-helm:
 	HELM_RELEASE=$(HELM_RELEASE) \
 	./newrelic_deployment.sh
 
+	HELM_NAMESPACE=$(HELM_NAMESPACE) \
 	HELM_RELEASE=$(HELM_RELEASE) \
 	./run_bash_script_in_php_pod.sh ls.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -279,4 +279,4 @@ deploy-helm:
 
 	HELM_NAMESPACE=$(HELM_NAMESPACE) \
 	HELM_RELEASE=$(HELM_RELEASE) \
-	./run_bash_script_in_php_pod.sh ls.sh
+	./run_bash_script_in_php_pod.sh modify_users.sh

--- a/src/ls.sh
+++ b/src/ls.sh
@@ -1,0 +1,2 @@
+//dummy script to test if the run_bash_script_in_php_pod works fine
+ls -l

--- a/src/modify_users.sh
+++ b/src/modify_users.sh
@@ -1,0 +1,22 @@
+wp user list --fields=user_login,user_email | grep amelekou; if [ $? != 0 ]; then wp user create amelekou amelekou@greenpeace.org --role=administrator --display_name="Anastasia" --first_name="Anastasia" --last_name="Melekou - Global Support" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep apapamat; if [ $? != 0 ]; then wp user create apapamat apapamat@greenpeace.org --role=administrator --display_name="Athanasios" --first_name="Athanasios" --last_name="Papamathaiou - Global Support" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep dgracian; if [ $? != 0 ]; then wp user create dgracian dgracian@greenpeace.org --role=administrator --display_name="Daniel" --first_name="Daniel" --last_name="Gracian - Global Support" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep eberger; if [ $? != 0 ]; then wp user create eberger eberger@greenpeace.org --role=administrator --display_name="Ernesto" --first_name="Ernesto" --last_name="Berger - Global Support" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep econsejo; if [ $? != 0 ]; then wp user create econsejo econsejo@greenpeace.org --role=administrator --display_name="Erick" --first_name="Erick" --last_name="Consejo - Global Support" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep tzetterl; if [ $? != 0 ]; then wp user create tzetterl tzetterl@greenpeace.org --role=administrator --display_name="Torbjorn" --first_name="Torbjorn" --last_name="Zetterlund - Global Support" --porcelain --quiet; fi
+
+
+wp user list --fields=user_login,user_email | grep atheodor; if [ $? != 0 ]; then wp user create atheodor atheodor@greenpeace.org --role=administrator --display_name="Angelos" --first_name="Angelos" --last_name="Theodorakopoulos  - P4 team" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep kdiamant; if [ $? != 0 ]; then wp user create kdiamant kdiamant@greenpeace.org --role=administrator --display_name="Kyriakos" --first_name="Kyriakos" --last_name="Diamantis  - P4 team" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep nroussos; if [ $? != 0 ]; then wp user create nroussos nroussos@greenpeace.org --role=administrator --display_name="Nikos" --first_name="Nikos" --last_name="Roussos  - P4 team" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep sdeshmuk; if [ $? != 0 ]; then wp user create sdeshmuk sdeshmuk@greenpeace.org --role=administrator --display_name="Sagar" --first_name="Sagar" --last_name="Deshmukh  - P4 team" --porcelain --quiet; fi
+
+wp user list --fields=user_login,user_email | grep rawalker; if [ $? != 0 ]; then wp user create rawalker rawalker@greenpeace.org --role=administrator --display_name="Ray" --first_name="Ray" --last_name="Walker  - P4 team" --porcelain --quiet; fi

--- a/src/run_bash_script_in_php_pod.sh
+++ b/src/run_bash_script_in_php_pod.sh
@@ -10,6 +10,6 @@ then
   >&2 echo "ERROR: php pod not found in release ${HELM_RELEASE}"
 fi
 
-kubectl -n ${HELM_NAMESPACE} cp $external_script $php:/app/bin/$external_script
-kubectl -n ${HELM_NAMESPACE} exec $php bash /app/bin/$external_script
-kubectl -n ${HELM_NAMESPACE} exec $php rm /app/bin/$external_script
+kubectl cp $external_script ${HELM_NAMESPACE}/$php:/app/bin/$external_script
+kubectl -n ${HELM_NAMESPACE} -p $php exec bash /app/bin/$external_script
+kubectl -n ${HELM_NAMESPACE} -p $php exec rm /app/bin/$external_script

--- a/src/run_bash_script_in_php_pod.sh
+++ b/src/run_bash_script_in_php_pod.sh
@@ -10,6 +10,6 @@ then
   >&2 echo "ERROR: php pod not found in release ${HELM_RELEASE}"
 fi
 
-kubectl cp $external_script $php:/app/source/public/$external_script
-kubectl exec ${HELM_NAMESPACE} $php bash /app/source/public/$external_script
-kubectl exec ${HELM_NAMESPACE} $php -- rm /app/source/public/$external_script
+kubectl cp $external_script $php:/app/bin/$external_script
+kubectl exec ${HELM_NAMESPACE} $php bash /app/bin/$external_script
+kubectl exec ${HELM_NAMESPACE} $php -- rm /app/bin/$external_script

--- a/src/run_bash_script_in_php_pod.sh
+++ b/src/run_bash_script_in_php_pod.sh
@@ -11,7 +11,5 @@ then
 fi
 
 kubectl cp $external_script $php:/app/source/public/$external_script
-kubectl exec ${HELM_NAMESPACE} $php -- chown app:app /app/source/public/$external_script
-kubectl exec ${HELM_NAMESPACE} $php -- chmod 744 /app/source/public/$external_script
 kubectl exec ${HELM_NAMESPACE} $php bash /app/source/public/$external_script
 kubectl exec ${HELM_NAMESPACE} $php -- rm /app/source/public/$external_script

--- a/src/run_bash_script_in_php_pod.sh
+++ b/src/run_bash_script_in_php_pod.sh
@@ -10,6 +10,6 @@ then
   >&2 echo "ERROR: php pod not found in release ${HELM_RELEASE}"
 fi
 
-kubectl cp $external_script $php:/app/bin/$external_script
-kubectl exec ${HELM_NAMESPACE} $php bash /app/bin/$external_script
-kubectl exec ${HELM_NAMESPACE} $php -- rm /app/bin/$external_script
+kubectl -n ${HELM_NAMESPACE} cp $external_script $php:/app/bin/$external_script
+kubectl -n ${HELM_NAMESPACE} exec $php bash /app/bin/$external_script
+kubectl -n ${HELM_NAMESPACE} exec $php rm /app/bin/$external_script

--- a/src/run_bash_script_in_php_pod.sh
+++ b/src/run_bash_script_in_php_pod.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eu
+
+external_script=$1
+
+php=$(kubectl get pods --namespace "${HELM_NAMESPACE}" -l "app=wordpress-php,release=${HELM_RELEASE}" -o jsonpath="{.items[0].metadata.name}")
+
+if [[ -z "$php" ]]
+then
+  >&2 echo "ERROR: php pod not found in release ${HELM_RELEASE}"
+fi
+
+kubectl cp $external_script $php:/app/source/public/$external_script
+kubectl exec ${HELM_NAMESPACE} $php -- chown app:app /app/source/public/$external_script
+kubectl exec ${HELM_NAMESPACE} $php -- chmod 744 /app/source/public/$external_script
+kubectl exec ${HELM_NAMESPACE} $php bash /app/source/public/$external_script
+kubectl exec ${HELM_NAMESPACE} $php -- rm /app/source/public/$external_script

--- a/src/run_bash_script_in_php_pod.sh
+++ b/src/run_bash_script_in_php_pod.sh
@@ -10,6 +10,6 @@ then
   >&2 echo "ERROR: php pod not found in release ${HELM_RELEASE}"
 fi
 
-kubectl cp $external_script ${HELM_NAMESPACE}/$php:/app/bin/$external_script
-kubectl -n ${HELM_NAMESPACE} -p $php exec bash /app/bin/$external_script
-kubectl -n ${HELM_NAMESPACE} -p $php exec rm /app/bin/$external_script
+kubectl -n ${HELM_NAMESPACE} cp $external_script $php:/app/bin/$external_script
+kubectl -n ${HELM_NAMESPACE} exec $php bash /app/bin/$external_script
+kubectl -n ${HELM_NAMESPACE} exec $php rm /app/bin/$external_script


### PR DESCRIPTION
Non tested, and very possibly breaking everything. Includes: 
- A meta script run_bash_script_in_php_pod.sh allowing us to run other bash scripts in the kubernetes pod php of given deploy
- A test bash script ls.sh  that just lists the current directory (so that we can test if the metascript works)
- A wp script modify_users.sh that adds missing users to a deployed wp installation (not used yet)
- A modification in the Makefile where we try to run the script ls.sh after a deploy.