### PR TITLE
Make the flush_redis able to run from anywhere

### DIFF
--- a/src/flush_redis.sh
+++ b/src/flush_redis.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 set -eu
 
+# Find real file path of current script
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+# determine where the flush_redis script lives
+source="${BASH_SOURCE[0]}"
+while [[ -h "$source" ]]
+do # resolve $source until the file is no longer a symlink
+          dir="$( cd -P "$( dirname "$source" )" && pwd )"
+            source="$(readlink "$source")"
+              [[ $source != /* ]] && source="$dir/$source" # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+      done
+      FLUSH_REDIS_DIR="$( cd -P "$( dirname "$source" )" && pwd )"
+      export FLUSH_REDIS_DIR
+
 # shellcheck disable=SC1091
-. lib/retry.sh
+. "${FLUSH_REDIS_DIR}/lib/retry.sh"
 
 function flush() {
   redis=$(kubectl get pods --namespace "${HELM_NAMESPACE}" \

--- a/src/flush_redis.sh
+++ b/src/flush_redis.sh
@@ -3,16 +3,14 @@ set -eu
 
 # Find real file path of current script
 # https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
-# determine where the flush_redis script lives
 source="${BASH_SOURCE[0]}"
 while [[ -h "$source" ]]
 do # resolve $source until the file is no longer a symlink
-          dir="$( cd -P "$( dirname "$source" )" && pwd )"
-            source="$(readlink "$source")"
-              [[ $source != /* ]] && source="$dir/$source" # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-      done
-      FLUSH_REDIS_DIR="$( cd -P "$( dirname "$source" )" && pwd )"
-      export FLUSH_REDIS_DIR
+    dir="$( cd -P "$( dirname "$source" )" && pwd )"
+    source="$(readlink "$source")"
+    [[ $source != /* ]] && source="$dir/$source" # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+FLUSH_REDIS_DIR="$( cd -P "$( dirname "$source" )" && pwd )"
 
 # shellcheck disable=SC1091
 . "${FLUSH_REDIS_DIR}/lib/retry.sh"


### PR DESCRIPTION
Doing it against the master, because the current develop was failing. 
The fix does not break the deployments. I run the :
https://circleci.com/workflow-run/568b6995-eeb2-4f9d-9a0f-1cf30a920b80
(and the follow up autodeployments) with gcr.io/planet-4-151612/p4-builder:build-209 which was build with this branch. 
The sync job also run without problems: 
https://circleci.com/workflow-run/376858ca-48ff-4039-8053-46cc71f84045
 
