### PR TITLE
PLANET-2991 Run local post deploy scripts that are in planet-nro post_deploy_scripts

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -279,3 +279,7 @@ deploy-helm:
 	HELM_NAMESPACE=$(HELM_NAMESPACE) \
 	HELM_RELEASE=$(HELM_RELEASE) \
 	./run_bash_script_in_php_pod.sh modify_users.sh "$(shell base64 -w 0 users.json)"
+
+	HELM_NAMESPACE=$(HELM_NAMESPACE) \
+	HELM_RELEASE=$(HELM_RELEASE) \
+	./run_post_deploy_scripts.sh

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for file in /tmp/workspace/src/post_deploy_scripts/*.sh; do
+    echo ""
+    echo "Running the local script : $(basename "$file")"
+    echo ""
+    $file
+done
+


### PR DESCRIPTION
This works if it finds a directory named post_deploy_scripts with any .sh files in it in the planet4-nro repository it runs. 
Proof of concept: https://github.com/greenpeace/planet4-koyansync/tree/develop/post_deploy_scripts
and https://circleci.com/gh/greenpeace/planet4-koyansync/328

One application could be to make the handbook configuration different from any other for the needs of the translation server