### PR TITLE
Rewrite master theme branches and fix checkout merge params

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -126,7 +126,7 @@ SOURCE_BUCKET_PATH  ?= $(BUILD_TAG)
 
 .PHONY: clean test rewrite checkout bake build build-app build-openresty pull push save
 
-all: test rewrite checkout bake build push save
+all: test rewrite checkout rewrite-app-repos bake build push save
 
 dev: clean rewrite checkout bake build
 
@@ -152,6 +152,10 @@ checkout:
 	MERGE_SOURCE=$(MERGE_SOURCE) \
 	MERGE_REF=$(MERGE_REF) \
 	./checkout.sh
+
+rewrite-app-repos:
+	MASTER_THEME_BRANCH=$(MASTER_THEME_BRANCH) \
+    ./rewrite_app_repos.sh
 
 rewrite:
 	GIT_REF=$(GIT_REF) \

--- a/src/checkout.sh
+++ b/src/checkout.sh
@@ -54,9 +54,9 @@ then
 else
   mkdir -p /home/circleci/merge
   cd /home/circleci/merge
-  git clone "$CIRCLE_REPOSITORY_URL" .
+  git clone "$MERGE_SOURCE" .
 fi
 
-git checkout "${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
+git checkout "$MERGE_REF"
 
 ls -al

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+FILE=/home/circleci/source/composer-local.json
+
+if [ ! -z "$MASTER_THEME_BRANCH" ]
+then
+    echo "Replacing master theme with branch ${MASTER_THEME_BRANCH}"
+    sed -i "s/\"greenpeace\/planet4-master-theme\" : \".*\",/\"greenpeace\/planet4-master-theme\" : \"${MASTER_THEME_BRANCH}\",/g" ${FILE}
+else
+    echo "Nothing to replace for the master theme"
+fi

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -10,3 +10,14 @@ then
 else
     echo "Nothing to replace for the master theme"
 fi
+
+
+FILE=/home/circleci/source/composer-local.json
+
+if [ ! -z "$MASTER_THEME_BRANCH" ]
+then
+    echo "Replacing master theme with branch ${MASTER_THEME_BRANCH}"
+    sed -i "s|\"greenpeace\/planet4-master-theme\" : \".*\",|\"greenpeace\/planet4-master-theme\" : \"${MASTER_THEME_BRANCH}\",|g" ${FILE}
+else
+    echo "Nothing to replace for the master theme"
+fi

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -12,7 +12,7 @@ else
 fi
 
 
-FILE=/home/circleci/build/source/composer.json
+FILE=/home/circleci/merge/composer.json
 
 if [ ! -z "$MASTER_THEME_BRANCH" ]
 then

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -6,18 +6,16 @@ FILE=/home/circleci/source/composer.json
 if [ ! -z "$MASTER_THEME_BRANCH" ]
 then
     echo "Replacing master theme with branch ${MASTER_THEME_BRANCH}"
+
+    FILE=/home/circleci/source/composer.json
     sed -i "s|\"greenpeace\/planet4-master-theme\" : \".*\",|\"greenpeace\/planet4-master-theme\" : \"${MASTER_THEME_BRANCH}\",|g" ${FILE}
-else
-    echo "Nothing to replace for the master theme"
-fi
 
-
-FILE=/home/circleci/merge/composer.json
-
-if [ ! -z "$MASTER_THEME_BRANCH" ]
-then
-    echo "Replacing master theme with branch ${MASTER_THEME_BRANCH}"
+    FILE=/home/circleci/merge/composer.json
     sed -i "s|\"greenpeace\/planet4-master-theme\" : \".*\",|\"greenpeace\/planet4-master-theme\" : \"${MASTER_THEME_BRANCH}\",|g" ${FILE}
+
+    echo "And now, delete any cached version of this package"
+    rm -rf /home/circleci/source/cache/files/greenpeace/planet4-master-theme
+
 else
     echo "Nothing to replace for the master theme"
 fi

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-FILE=/home/circleci/build/source/composer-local.json
-
-if [ ! -z "$MASTER_THEME_BRANCH" ]
-then
-    echo "Replacing master theme with branch ${MASTER_THEME_BRANCH}"
-    sed -i "s|\"greenpeace\/planet4-master-theme\" : \".*\",|\"greenpeace\/planet4-master-theme\" : \"${MASTER_THEME_BRANCH}\",|g" ${FILE}
-else
-    echo "Nothing to replace for the master theme"
-fi
-
-
-FILE=/home/circleci/source/composer-local.json
+FILE=/home/circleci/source/composer.json
 
 if [ ! -z "$MASTER_THEME_BRANCH" ]
 then

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -10,3 +10,18 @@ then
 else
     echo "Nothing to replace for the master theme"
 fi
+
+
+FILE=/home/circleci/build/source/composer.json
+
+if [ ! -z "$MASTER_THEME_BRANCH" ]
+then
+    echo "Replacing master theme with branch ${MASTER_THEME_BRANCH}"
+    sed -i "s|\"greenpeace\/planet4-master-theme\" : \".*\",|\"greenpeace\/planet4-master-theme\" : \"${MASTER_THEME_BRANCH}\",|g" ${FILE}
+else
+    echo "Nothing to replace for the master theme"
+fi
+
+
+echo "DEBUG: We will echo where master theme is defined as what: "
+grep -r -H '"greenpeace/planet4-master-theme" :' *

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -ex
 
-FILE=/home/circleci/source/composer-local.json
+FILE=/home/circleci/build/source/composer-local.json
 
 if [ ! -z "$MASTER_THEME_BRANCH" ]
 then
     echo "Replacing master theme with branch ${MASTER_THEME_BRANCH}"
-    sed -i "s/\"greenpeace\/planet4-master-theme\" : \".*\",/\"greenpeace\/planet4-master-theme\" : \"${MASTER_THEME_BRANCH}\",/g" ${FILE}
+    sed -i "s|\"greenpeace\/planet4-master-theme\" : \".*\",|\"greenpeace\/planet4-master-theme\" : \"${MASTER_THEME_BRANCH}\",|g" ${FILE}
 else
     echo "Nothing to replace for the master theme"
 fi


### PR DESCRIPTION
Two changes. (Name of branch implies only one)
1) If a variable named `MASTER_THEME_BRANCH` exists when builder's `make` is called, these changes replace the tag/branch in composer.json with the given one. Like that we can change the master-theme on the fly while building, and we can do testing on specific branches. (Similar work will follow for other plugins)

2) Fixed an error with checkout.sh: Even though in `make` the checkout was being called as: 
```
checkout:
	GIT_SOURCE=$(GIT_SOURCE) \
	GIT_REF=$(GIT_REF) \
	MERGE_SOURCE=$(MERGE_SOURCE) \
	MERGE_REF=$(MERGE_REF) \
	./checkout.sh
```
The last two parameters (MERGE_SOURCE and MERGE_REF) where not being taken into account. Fixed that. 