### PR TITLE
Feature/run global post deploy scripts

### DIFF
--- a/src/run_bash_script_in_php_pod.sh
+++ b/src/run_bash_script_in_php_pod.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # First parameter is name of script to execute in the PHP pod
 external_script=$1
+base_external_script=$(basename "$external_script")
 shift
 
 if [[ ! -e "$external_script" ]]
@@ -23,6 +24,6 @@ then
   exit 1
 fi
 
-kubectl -n "${HELM_NAMESPACE}" cp "$external_script" "$php:/tmp/$external_script"
-kubectl -n "${HELM_NAMESPACE}" exec "$php" -- "/tmp/$external_script" "$*"
-kubectl -n "${HELM_NAMESPACE}" exec "$php" -- rm "/tmp/$external_script"
+kubectl -n "${HELM_NAMESPACE}" cp "$external_script" "$php:/tmp/$base_external_script"
+kubectl -n "${HELM_NAMESPACE}" exec "$php" -- "/tmp/$base_external_script" "$*"
+kubectl -n "${HELM_NAMESPACE}" exec "$php" -- rm "/tmp/$base_external_script"

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -26,7 +26,7 @@ for file in tasks/post-deploy/*; do
     echo ""
     echo "Running the common script : $(basename "$file")"
     echo ""
-    HELM_NAMESPACE=$(HELM_NAMESPACE) \
-	  HELM_RELEASE=$(HELM_RELEASE) \
+    HELM_NAMESPACE=${HELM_NAMESPACE} \
+	  HELM_RELEASE=${HELM_RELEASE} \
 	  ./run_bash_script_in_php_pod.sh modify_users.sh "$(shell base64 -w 0 users.json)"
 done

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -29,5 +29,5 @@ for file in source/tasks/post-deploy/*; do
     echo ""
     HELM_NAMESPACE=${HELM_NAMESPACE} \
 	  HELM_RELEASE=${HELM_RELEASE} \
-	  ./run_bash_script_in_php_pod.sh source/tasks/post-deploy/${file} "$(shell base64 -w 0 users.json)"
+	  ./run_bash_script_in_php_pod.sh $file
 done

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -29,5 +29,5 @@ for file in source/tasks/post-deploy/*; do
     echo ""
     HELM_NAMESPACE=${HELM_NAMESPACE} \
 	  HELM_RELEASE=${HELM_RELEASE} \
-	  ./run_bash_script_in_php_pod.sh modify_users.sh "$(shell base64 -w 0 users.json)"
+	  ./run_bash_script_in_php_pod.sh source/tasks/post-deploy/${file} "$(shell base64 -w 0 users.json)"
 done

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -18,6 +18,7 @@ done
 
 echo "Now check the common post deploy scripts and run them as well"
 
+mkdir source
 pushd source
 git pull https://github.com/greenpeace/planet4-base-fork .
 

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -20,7 +20,7 @@ echo "Now check the common post deploy scripts and run them as well"
 
 mkdir source
 pushd source
-git pull https://github.com/greenpeace/planet4-base-fork .
+git clone https://github.com/greenpeace/planet4-base-fork .
 
 for file in tasks/post-deploy/*; do
     echo ""

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -15,3 +15,17 @@ for file in $(kubectl -n "${HELM_NAMESPACE}" exec $php -- ls ./post_deploy_scrip
     kubectl -n "${HELM_NAMESPACE}" exec "$php" -- bash "post_deploy_scripts/$file"
 done
 
+
+echo "Now check the common post deploy scripts and run them as well"
+
+pushd source
+git pull https://github.com/greenpeace/planet4-base-fork .
+
+for file in tasks/post-deploy/*; do
+    echo ""
+    echo "Running the common script : $(basename "$file")"
+    echo ""
+    HELM_NAMESPACE=$(HELM_NAMESPACE) \
+	  HELM_RELEASE=$(HELM_RELEASE) \
+	  ./run_bash_script_in_php_pod.sh modify_users.sh "$(shell base64 -w 0 users.json)"
+done

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -21,8 +21,9 @@ echo "Now check the common post deploy scripts and run them as well"
 mkdir source
 pushd source
 git clone https://github.com/greenpeace/planet4-base-fork .
+popd
 
-for file in tasks/post-deploy/*; do
+for file in source/tasks/post-deploy/*; do
     echo ""
     echo "Running the common script : $(basename "$file")"
     echo ""


### PR DESCRIPTION
This is working and can be seen at: https://circleci.com/gh/greenpeace/planet4-koyansync/462

(at the end of the last step):
```
Running the common script : 01-flush_permalinks.sh

Success: Rewrite rules flushed.
```

![post-deploy-scripts-global](https://user-images.githubusercontent.com/2528229/51544353-6287a680-1e68-11e9-9212-c81a58a82390.png)

It runs scripts that live in planet4-base-fork:tasks/post-deploy


