### PR TITLE
PLANET-3163 Rationalise post deploy scripts

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -176,11 +176,12 @@ copy:
 	# Copy merge files to build container context, overwriting as required
 	[[ -d merge ]] && rsync --exclude '.git' -a merge/ build/source
 
-persist:
-	rsync a --delete build/source /tmp/workspace/src
-
 bake:
 	source ./lib/retry.sh && retry ./bake.sh | tee source/bake.log
+
+persist:
+	# Copy the source data in the persistence workspace
+	rsync -a --exclude 'cache' build/source/* /tmp/workspace/src
 
 build: rewrite build-app build-openresty
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -129,7 +129,7 @@ SOURCE_BUCKET_PATH  ?= $(BUILD_TAG)
 
 .PHONY: clean test rewrite checkout bake build build-app build-openresty pull push save
 
-all: test rewrite checkout rewrite-app-repos merge bake persist build push save
+all: test rewrite checkout rewrite-app-repos copy bake persist build push save
 
 dev: clean rewrite checkout bake build
 
@@ -170,7 +170,7 @@ rewrite:
 	MERGE_SOURCE=$(MERGE_SOURCE) \
 	./rewrite_dockerfiles.sh
 
-merge:
+copy:
 	# Copy source files to build container context
 	[[ -d source ]] && rsync --exclude '.git' -a source/ build/source
 	# Copy merge files to build container context, overwriting as required

--- a/src/Makefile
+++ b/src/Makefile
@@ -129,7 +129,7 @@ SOURCE_BUCKET_PATH  ?= $(BUILD_TAG)
 
 .PHONY: clean test rewrite checkout bake build build-app build-openresty pull push save
 
-all: test rewrite checkout rewrite-app-repos bake build push save
+all: test rewrite checkout rewrite-app-repos merge bake persist build push save
 
 dev: clean rewrite checkout bake build
 
@@ -169,6 +169,15 @@ rewrite:
 	MERGE_REF=$(MERGE_REF) \
 	MERGE_SOURCE=$(MERGE_SOURCE) \
 	./rewrite_dockerfiles.sh
+
+merge:
+	# Copy source files to build container context
+	[[ -d source ]] && rsync --exclude '.git' -a source/ build/source
+	# Copy merge files to build container context, overwriting as required
+	[[ -d merge ]] && rsync --exclude '.git' -a merge/ build/source
+
+persist:
+	rsync a --delete build/source /tmp/workspace/src
 
 bake:
 	source ./lib/retry.sh && retry ./bake.sh | tee source/bake.log

--- a/src/bake.sh
+++ b/src/bake.sh
@@ -13,12 +13,6 @@ generated files for use elsewhere.
 # Create composer cache directory if not exist
 mkdir -p source/cache
 
-# Copy source files to build container context
-[[ -d source ]] && rsync --exclude '.git' -a source/ build/source
-
-# Copy merge files to build container context, overwriting as required
-[[ -d merge ]] && rsync --exclude '.git' -a merge/ build/source
-
 # ----------------------------------------------------------------------------
 
 docker-compose -p build down -v --remove-orphans

--- a/src/bake.sh
+++ b/src/bake.sh
@@ -71,7 +71,6 @@ docker ps
 php_container=$(docker-compose -p build ps -q php-fpm)
 
 echo "Copying build artifacts..."
-docker cp "$php_container:/app/source/bake.log" source
 docker cp "$php_container:/app/source/cache" source
 docker cp "$php_container:/app/source/public" source
 

--- a/src/checkout.sh
+++ b/src/checkout.sh
@@ -59,4 +59,7 @@ fi
 
 git checkout "$MERGE_REF"
 
+# Copy common post-deploy scripts
+cp /home/circleci/source/tasks/post-deploy/* /home/circleci/merge/post_deploy_scripts
+
 ls -al

--- a/src/checkout.sh
+++ b/src/checkout.sh
@@ -59,7 +59,4 @@ fi
 
 git checkout "$MERGE_REF"
 
-# Copy common post-deploy scripts
-cp /home/circleci/source/tasks/post-deploy/* /home/circleci/merge/post_deploy_scripts
-
 ls -al

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -9,9 +9,6 @@ workspace=/tmp/workspace/src
   exit 0
 }
 
-cp -f "$workspace/post_deploy_scripts/*" "$workspace/tasks/post-deploy"
-rm -rf "$workspace/post_deploy_scripts"
-
 for file in "$workspace"/tasks/post-deploy/*
 do
     echo ""

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -9,23 +9,7 @@ php=$(kubectl get pods --namespace "${HELM_NAMESPACE}" \
 
 for file in $(kubectl -n "${HELM_NAMESPACE}" exec "$php" -- ls ./post_deploy_scripts); do
     echo ""
-    echo "Running the local script : $(basename "$file")"
+    echo "Running the script : $(basename "$file")"
     echo ""
     kubectl -n "${HELM_NAMESPACE}" exec "$php" -- bash "post_deploy_scripts/$file"
-done
-
-echo "Now check the common post deploy scripts and run them as well"
-
-mkdir source
-pushd source
-git clone https://github.com/greenpeace/planet4-base-fork .
-popd
-
-for file in source/tasks/post-deploy/*; do
-    echo ""
-    echo "Running the common script : $(basename "$file")"
-    echo ""
-    HELM_NAMESPACE=${HELM_NAMESPACE} \
-	  HELM_RELEASE=${HELM_RELEASE} \
-	  ./run_bash_script_in_php_pod.sh "$file"
 done

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-php=$(kubectl get pods --namespace "${HELM_NAMESPACE}" \
-  --sort-by=.metadata.creationTimestamp \
-  --field-selector=status.phase=Running \
-  -l "app=wordpress-php,release=${HELM_RELEASE}" \
-  -o jsonpath="{.items[-1:].metadata.name}")
 
-for file in $(kubectl -n "${HELM_NAMESPACE}" exec "$php" -- ls ./post_deploy_scripts); do
-    echo ""
-    echo "Running the script : $(basename "$file")"
-    echo ""
-    kubectl -n "${HELM_NAMESPACE}" exec "$php" -- bash "post_deploy_scripts/$file"
-done
+echo "Check the post deploy scripts and run them as well"
+echo "Check if merged source is persisted from previous job"
+if [ -d /tmp/workspace/src/tasks/post-deploy ]; then
+
+    cp -f /tmp/workspace/src/post_deploy_scripts/* /tmp/workspace/src/tasks/post-deploy
+
+    for file in /tmp/workspace/src/tasks/post-deploy/*; do
+        echo ""
+        echo "Running the script : $(basename "$file")"
+        echo ""
+        HELM_NAMESPACE=${HELM_NAMESPACE} \
+          HELM_RELEASE=${HELM_RELEASE} \
+          ./run_bash_script_in_php_pod.sh "$file"
+    done
+fi

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+workspace=/tmp/workspace/src
 
-echo "Check the post deploy scripts and run them as well"
-echo "Check if merged source is persisted from previous job"
-if [ -d /tmp/workspace/src/tasks/post-deploy ]; then
+[ -d "$workspace/tasks/post-deploy" ] || {
+  echo "No post-deploy task folder found in $workspace"
+  ls -al "$workspace"
+  exit 0
+}
 
-    cp -f /tmp/workspace/src/post_deploy_scripts/* /tmp/workspace/src/tasks/post-deploy
+find "$workspace" -type f
 
-    for file in /tmp/workspace/src/tasks/post-deploy/*; do
-        echo ""
-        echo "Running the script : $(basename "$file")"
-        echo ""
-        HELM_NAMESPACE=${HELM_NAMESPACE} \
-          HELM_RELEASE=${HELM_RELEASE} \
-          ./run_bash_script_in_php_pod.sh "$file"
-    done
-fi
+cp -f "$workspace/post_deploy_scripts/*" "$workspace/tasks/post-deploy"
+
+for file in "$workspace"/tasks/post-deploy/*
+do
+    echo ""
+    echo "Running the script : $(basename "$file")"
+    echo ""
+    ./run_bash_script_in_php_pod.sh "$file"
+done

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -9,9 +9,8 @@ workspace=/tmp/workspace/src
   exit 0
 }
 
-find "$workspace" -type f
-
 cp -f "$workspace/post_deploy_scripts/*" "$workspace/tasks/post-deploy"
+rm -rf "$workspace/post_deploy_scripts"
 
 for file in "$workspace"/tasks/post-deploy/*
 do


### PR DESCRIPTION
Check if base-fork post-deploy scripts are persisted from previous job, before cloning base-fork repo

You can check it out in this ci [build](https://circleci.com/gh/greenpeace/planet4-koyansync/538)

In conjuction with changes done in [koyan-sync](https://github.com/greenpeace/planet4-koyansync/commit/b514ccfdd43d48c954d387141ed477e05d9bf4eb).
