### PR TITLE
Support building application images from different parents.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,8 @@ SHELL := /bin/bash
 MAINTAINER        ?= Raymond Walker <raymond.walker@greenpeace.org>
 
 # https://github.com/greenpeace/planet4-docker
-INFRA_VERSION     ?= latest
+PARENT_IMAGE			?= gcr.io/planet-4-151612/wordpress
+PARENT_VERSION    ?= latest
 
 # Wordpress Helm chart version
 CHART_VERSION 		?= 0.4.0
@@ -137,14 +138,13 @@ dev: clean rewrite checkout bake build
 
 test:
 	set -eu
-	@echo "Building $(CONTAINER_PREFIX) containers..."
+	@echo "Building $(CONTAINER_PREFIX):$(BUILD_TAG) containers..."
+	@echo "PARENT_IMAGE:      $(PARENT_IMAGE)"
 	@echo "APP_HOSTNAME:      $(APP_HOSTNAME)"
 	@echo "APP_HOSTPATH:      $(APP_HOSTPATH)"
 	@echo "NEWRELIC_APPNAME:  $(NEWRELIC_APPNAME)"
-	@echo "INFRA_VERSION:     $(INFRA_VERSION)"
-	@echo "BUILD_TAG:         $(BUILD_TAG)"
-	@echo "MERGE_REF:         $(MERGE_REF)"
 	@echo "GIT_REF:           $(GIT_REF)"
+	@echo "MERGE_REF:         $(MERGE_REF)"
 	@echo ""
 
 clean:

--- a/src/build/Dockerfile.in
+++ b/src/build/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM gcr.io/planet-4-151612/wordpress:${INFRA_VERSION}
+FROM ${PARENT_IMAGE}:${PARENT_VERSION}
 
 LABEL authors="${MAINTAINER}"
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.2'
 services:
   app:
     container_name: build_proxy
-    image: gcr.io/planet-4-151612/openresty:${INFRA_VERSION:-develop}
+    image: gcr.io/planet-4-151612/openresty:${PARENT_VERSION:-develop}
     volumes:
       - type: volume
         source: data

--- a/src/helm_deploy.sh
+++ b/src/helm_deploy.sh
@@ -14,7 +14,7 @@ function install() {
     --version "${CHART_VERSION}" \
     --set dbDatabase="${WP_DB_NAME}" \
     --set environment="${APP_ENVIRONMENT}" \
-    --set exim.image.tag="${INFRA_VERSION}" \
+    --set exim.image.tag="${PARENT_VERSION}" \
     --set hostname="${APP_HOSTNAME}" \
     --set hostpath="${APP_HOSTPATH}" \
     --set newrelic.appname="${NEWRELIC_APPNAME}" \

--- a/src/openresty/Dockerfile.in
+++ b/src/openresty/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM gcr.io/planet-4-151612/openresty:${INFRA_VERSION}
+FROM gcr.io/planet-4-151612/openresty:${PARENT_VERSION}
 
 LABEL authors="Raymond Walker <raymond.walker@greenpeace.org>"
 

--- a/src/rewrite_dockerfiles.sh
+++ b/src/rewrite_dockerfiles.sh
@@ -6,7 +6,7 @@ export SOURCE_PATH=/app/source
 # Specify which Dockerfile|README.md variables we want to change
 # shellcheck disable=SC2016
 # envvars=(
-#   '${INFRA_VERSION}' \
+#   '${PARENT_VERSION}' \
 #   '${GIT_REF}' \
 #   '${GIT_SOURCE}' \
 #   '${GOOGLE_PROJECT_ID}' \


### PR DESCRIPTION
Enables building the application image from an arbitrary parent.

Defaults to, but no longer hard-coded to `gcr.io/planet-4-151612/wordpress`

Configure via NRO `.circleci/config.yml` PARENT_IMAGE environment variable.

Tested in
- https://circleci.com/gh/greenpeace/planet4-flibble/1817
- https://circleci.com/gh/greenpeace/planet4-flibble/1819