### PR TITLE
PLANET-2668: Automate testing of new versions of plugins using RIPPs on the cloud

### DIFF
--- a/src/rips_scan_tag.sh
+++ b/src/rips_scan_tag.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-TAG_NAME="$(curl -s https://api.github.com/repos/greenpeace/${RIPS_SCAN_REPO}/tags | jq -r '.[0].name')"
-TAG_COMMIT="$(curl -s https://api.github.com/repos/greenpeace/${RIPS_SCAN_REPO}/tags | jq -r '.[0].commit.sha')"
+# Default organisation is 'greenpeace'
+ORG=${1:-greenpeace}
 
-APPLICATION_ID=${RIPS_APPLICATION_ID}
+# Default repository is current repo
+REPO=${2:-$CIRCLE_PROJECT_REPONAME}
 
-echo "Downloading zip archive for tag: ${TAG_NAME}"
-
-wget https://github.com/greenpeace/planet4-master-theme/archive/${TAG_COMMIT}.zip
+ZIPBALL_URL=$(curl -s "https://api.github.com/repos/${ORG}/${REPO}/tags" | jq -r '.[0].zipball_url')
+wget "${ZIPBALL_URL}" -O "${REPO}.zip"
 
 wget https://github.com/rips/rips-cli/releases/download/1.2.1/rips-cli.phar -O ./rips-cli
 chmod 755 ./rips-cli
 
-./rips-cli rips:scan:start -a ${RIPS_APPLICATION_ID} -p ./${TAG_COMMIT}.zip
+./rips-cli rips:scan:start -a ${RIPS_APPLICATION_ID} -p ./${REPO}.zip

--- a/src/rips_scan_tag.sh
+++ b/src/rips_scan_tag.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+TAG_NAME="$(curl -s https://api.github.com/repos/greenpeace/${RIPS_SCAN_REPO}/tags | jq -r '.[0].name')"
+TAG_COMMIT="$(curl -s https://api.github.com/repos/greenpeace/${RIPS_SCAN_REPO}/tags | jq -r '.[0].commit.sha')"
+
+APPLICATION_ID=${RIPS_APPLICATION_ID}
+
+echo "Downloading zip archive for tag: ${TAG_NAME}"
+
+wget https://github.com/greenpeace/planet4-master-theme/archive/${TAG_COMMIT}.zip
+
+wget https://github.com/rips/rips-cli/releases/download/1.2.1/rips-cli.phar -O ./rips-cli
+chmod 755 ./rips-cli
+
+./rips-cli rips:scan:start -a ${RIPS_APPLICATION_ID} -p ./${TAG_COMMIT}.zip

--- a/src/rips_scan_tag.sh
+++ b/src/rips_scan_tag.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The application ID is required
+RIPS_APPLICATION_ID=$1
+
 # Default organisation is 'greenpeace'
-ORG=${1:-greenpeace}
+ORG=${2:-greenpeace}
 
 # Default repository is current repo
-REPO=${2:-$CIRCLE_PROJECT_REPONAME}
+REPO=${3:-$CIRCLE_PROJECT_REPONAME}
 
 ZIPBALL_URL=$(curl -s "https://api.github.com/repos/${ORG}/${REPO}/tags" | jq -r '.[0].zipball_url')
-wget "${ZIPBALL_URL}" -O "${REPO}.zip"
+wget "${ZIPBALL_URL}" -O "${REPO}".zip
 
 wget https://github.com/rips/rips-cli/releases/download/1.2.1/rips-cli.phar -O ./rips-cli
 chmod 755 ./rips-cli
 
-./rips-cli rips:scan:start -a ${RIPS_APPLICATION_ID} -p ./${REPO}.zip
+./rips-cli rips:scan:start -a "${RIPS_APPLICATION_ID}" -p ./"${REPO}".zip


### PR DESCRIPTION
This adds a script to automate the download of a zip archive for a given tag of a Greenpeace repo, download RIPS-CLI, and then upload the file to RIPS to initiate the scan.

Ref: https://jira.greenpeace.org/browse/PLANET-2668

See also: related PR on the master theme repo: https://github.com/greenpeace/planet4-master-theme/pull/778
