### PR TITLE
USE release branches in staging sites

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,6 +20,20 @@ CONTAINER_PREFIX  ?= planet4-test
 
 # Configure composer source and merge repository data
 
+# Define APP_ENVIRONMENT because we need it in order to know what GIT_REF to use
+APP_ENVIRONMENT     ?= production
+
+# The branch to checkout of GIT_SOURCE, eg:
+# Use local branch name if not set
+
+ifeq ($(strip $(APP_ENVIRONMENT)),staging)
+GIT_REF 		  ?= release
+else ifeq ($(strip $(APP_ENVIRONMENT)),development)
+GIT_REF           ?= develop
+else
+GIT_REF           ?= master
+endif
+
 # Base composer project repository
 # FIXME change this to greenpeace/planet4-base once things are settled
 GIT_SOURCE        ?= https://github.com/greenpeace/planet4-base-fork
@@ -65,7 +79,7 @@ ifeq ($(APP_HOSTPATH),<nil>)
 # So if APP_HOSTPATH is set, but blank, clean this value
 APP_HOSTPATH :=
 endif
-APP_ENVIRONMENT     ?= production
+# APP_ENVIRONMENT     ?= production
 BUILD_NAMESPACE     ?= gcr.io
 GOOGLE_PROJECT_ID   ?= planet-4-151612
 NEWRELIC_APPNAME    ?= Greenpeace Planet4 Wordpress Test


### PR DESCRIPTION
PLANET-3532 . Use the release branch of the planet4-base-fork for staging sites, the develop branch for develop sites and the master branch for production sites. 

This will modify the release process, since after this gets merged and deployed, when we do a release to production we will have to be aware which branch of planet4-base-fork we are pushing, and what they have inside them.

An example can be seen in the koyansync website. Checking circleCI, the last 3 successful builds/deploys (of develop, staging, production sites respectively) used the relevant planet4-base-fork branches
Check them out by looking at the build job -> step called "Make", the GIT_REF variable.
Also can be seen at the p4-dev report of the koyansync develop and staging sites

![3532-build-develop](https://user-images.githubusercontent.com/2528229/57834787-bc203200-77c5-11e9-986a-eb693b314712.png)
![3532-build-master](https://user-images.githubusercontent.com/2528229/57834788-bc203200-77c5-11e9-8441-4271ee727ae1.png)
![3532-build-staging](https://user-images.githubusercontent.com/2528229/57834789-bcb8c880-77c5-11e9-920f-5b05449805a4.png)

![3532-dev-site-report](https://user-images.githubusercontent.com/2528229/57834914-099c9f00-77c6-11e9-879b-601db7a50085.png)
![3532-staging-site-report](https://user-images.githubusercontent.com/2528229/57834915-099c9f00-77c6-11e9-993a-45452b4c24d2.png)
