### PR TITLE
PLANET-4427 Make builder build assets for dev branches

### DIFF
--- a/src/build/Dockerfile.in
+++ b/src/build/Dockerfile.in
@@ -27,3 +27,8 @@ RUN \
     fi && \
     time composer -v update --lock --no-dev --no-ansi && \
     time composer -v install --no-dev --no-ansi --no-interaction
+
+RUN \
+    if [ -d ${SOURCE_PATH}/built-dev-assets/ ]; then \
+        rsync -av ${SOURCE_PATH}/built-dev-assets/ ${SOURCE_PATH}/ && rm -rf ${SOURCE_PATH}/built-dev-assets; \
+    fi

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -1,35 +1,42 @@
 #!/usr/bin/env bash
 set -ex
 
-files=(
+composer_files=(
   "${HOME}/source/composer.json"
   "${HOME}/source/composer-local.json"
   "${HOME}/merge/composer.json"
   "${HOME}/merge/composer-local.json"
 )
 
-branches=(
+plugin_branch_env_vars=(
   "MASTER_THEME_BRANCH"
   "PLUGIN_BLOCKS_BRANCH"
+  "PLUGIN_GUTENBERG_BLOCKS_BRANCH"
   "PLUGIN_ENGAGINGNETWORKS_BRANCH"
+  "PLUGIN_GUTENBERG_ENGAGINGNETWORKS_BRANCH"
 )
+
+built_assets_dir="${HOME}/source/built-dev-assets"
+mkdir -p "${built_assets_dir}"
 
 echo "rewrite_app_repos"
 
-for branch in "${branches[@]}"
+for plugin_branch_env_var in "${plugin_branch_env_vars[@]}"
 do
-  reponame=$( echo "${branch%_*}" | tr '[:upper:]' '[:lower:]' | sed 's/_/-/g')
+  reponame=planet4-$( echo "${plugin_branch_env_var%_*}" | tr '[:upper:]' '[:lower:]' | sed 's/_/-/g')
+  composer_dev_prefix="dev-"
+  # temp solution to remove it and add it again where it is needed. It would be better if this script got branchname
+  # without dev- before it, so stripping it as the first thing allows us to change that
+  branch=${!plugin_branch_env_var#"$composer_dev_prefix"}
 
-  if [ -n "${!branch}" ] ; then
-
-    echo "Replacing ${reponame} with branch ${!branch}"
-
-    for f in "${files[@]}"
+  if [ -n "${!plugin_branch_env_var}" ]; then
+    echo "Replacing ${reponame} with branch ${branch} from environment variable"
+    for f in "${composer_files[@]}"
     do
       if [ -e "$f" ]
       then
         echo " - $f"
-        sed -i "s|\"greenpeace\\/planet4-${reponame}\" : \".*\",|\"greenpeace\\/planet4-${reponame}\" : \"${!branch}\",|g" "${f}"
+        sed -i "s|\"greenpeace\\/${reponame}\" : \".*\",|\"greenpeace\\/${reponame}\" : \"dev-${branch}\",|g" "${f}"
       fi
     done
 
@@ -39,8 +46,49 @@ do
   else
     echo "Nothing to replace for the ${reponame}"
   fi
+
+  # now go throuhg the composer file and see if there are any dev branches for planet4 plugins or theme
+  for f in "${composer_files[@]}"
+  do
+    if [ -e "$f" ]; then
+      json_path=".require.\"greenpeace/${reponame}\""
+      plugin_version=$(jq -r "${json_path}" < "${f}")
+      branch=${plugin_version#"$composer_dev_prefix"}
+
+      # if these are the same do nothing as plugin is not in file or it doesn't start with "dev-"
+      # master already includes built files
+      if [[ "${branch}" != "${plugin_version}" ]] && [ "${branch}" != master ]; then
+        # dev branches do not include the built assets, only master does. So we need to build them here.
+        # All built files are put together in built-dev-assets, which has the same directory structure as /app/source.
+        # In the last step in the Dockerfile the contents of this directory are rsync'ed over the source.
+        # This is not ideal, however there was no better alternative as packagist only works with files in a github repo.
+        echo "Building assets for ${reponame} at branch ${branch}"
+
+        git clone --recurse-submodules --single-branch --branch "${branch}" https://github.com/greenpeace/"${reponame}"
+
+        time npm ci --prefix "${reponame}" "${reponame}"
+        time npm run-script --prefix "${reponame}" build
+
+        if [[ "${reponame}" == *theme ]]; then \
+            subdir="themes"; \
+        else \
+            subdir="plugins"; \
+        fi; \
+
+        buildDir="${built_assets_dir}/public/wp-content/${subdir}/${reponame}/assets/build/"
+        mkdir -p "${buildDir}"
+        cp -a "${reponame}/assets/build/." "${buildDir}"
+        rm -rf "${reponame}"
+      else
+        if [ -z "${plugin_version}" ]; then
+          echo "Plugin ${reponame} is not in ${f}"
+        else
+          echo "Version ${plugin_version} for ${reponame} in ${f} is not a branch"
+        fi
+      fi
+    fi
+  done
 done
 
 echo "DEBUG: We will echo where master theme is defined as what: "
 grep -r -H '"greenpeace/planet4-master-theme" :' ./*
-


### PR DESCRIPTION
* Get github repository, build assets, and put all built assets in a
directory in the source directory for all plugins that have their
dev version passed using a branch name. That directory has the same
structure as the source directory.
* Use rsync to apply that directory like a patch.
* Add environment variables for newer plugins so that these are also
tested.