### PR TITLE
PLANET-5192 Ensure sed matches regardless of space

### DIFF
--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -57,7 +57,7 @@ do
       if [ -e "$f" ]
       then
         echo " - $f"
-        sed -i "s|\"greenpeace\\/${reponame}\" : \".*\",|\"greenpeace\\/${reponame}\" : \"dev-${branch}\",|g" "${f}"
+        sed -i "s|\"greenpeace\\/${reponame}\" \?: \".*\",|\"greenpeace\\/${reponame}\" : \"dev-${branch}\",|g" "${f}"
       fi
     done
 


### PR DESCRIPTION
* Sed expected a space between the package name and the colon, however
this space is not there for some of the repos. The result was that sed
didn't replace anything, causing further jobs to not have the intended
version of the plugins. This fixes the issue for now, however depending
on regex substitution is error prone so we should do this in a more
robust way.