### PR TITLE
PLANET-5221 use jq and support fork PRs

### DIFF
--- a/src/get-fork-pr-branch.sh
+++ b/src/get-fork-pr-branch.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC2034
+url="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}"
+CIRCLE_PR_BRANCH=$(curl -s "$url" | jq -r '.head.ref')
+
+echo "$CIRCLE_PR_BRANCH"

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -118,7 +118,7 @@ do
 
   if [ -n "$repo_branch" ]; then
     echo "Building assets for ${reponame} at branch ${repo_branch}"
-    time build_assets "$repo_branch" "$reponame" &
+    time PS4="__$reponame: " build_assets "$repo_branch" "$reponame" &
     pids+=($!)
   fi
 done

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -26,9 +26,10 @@ build_assets() {
 
   # If the repository name is the repository of the current job, the code will already be checked out, even if it's a
   # fork PR.
-  if [ "$CIRCLE_PROJECT_REPONAME" == "$reponame" ]; then
+  checkoutDir="/home/circleci/checkout/${reponame}"
+  if [ "$CIRCLE_PROJECT_REPONAME" == "$reponame" ] && [ -d "${checkoutDir}" ]; then
     mkdir -p "$reponame"
-    cp -r "/home/circleci/checkout/${reponame}/." "$reponame"
+    cp -r "${checkoutDir}/." "$reponame"
     git -C "$reponame" submodule init
     git -C "$reponame" submodule update --remote
   else
@@ -69,10 +70,11 @@ do
         jq ".require.\"greenpeace/${reponame}\" = \"dev-${branch}\"" "$f" > "$tmp"
         mv "$tmp" "$f"
 
+        checkoutDir="/home/circleci/checkout/${reponame}"
         # If builder is running for the theme or plugin, then we can use the checked out code of the current commit.
-        if [ "$CIRCLE_PROJECT_REPONAME" == "$reponame" ]; then
+        if [ "$CIRCLE_PROJECT_REPONAME" == "$reponame" ] && [ -d "${checkoutDir}" ]; then
           tmp=$(mktemp)
-          jq ".repositories |= [{\"type\": \"path\", \"url\": \"/home/circleci/checkout/${reponame}\"}] + ." "$f" > "$tmp"
+          jq ".repositories |= [{\"type\": \"path\", \"url\": \"${checkoutDir}\"}] + ." "$f" > "$tmp"
           mv "$tmp" "$f"
         fi
       fi

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -26,7 +26,14 @@ build_assets() {
   branch="$1"
   reponame="$2"
 
-  git clone --recurse-submodules --single-branch --branch "${branch}" https://github.com/greenpeace/"${reponame}"
+  if [ -n "$FORK_USER" ] && [ "$FORK_REPO" == "$reponame" ]; then
+    mkdir -p "$reponame"
+    cp -r /home/circleci/theme-src/. "$reponame"
+    git -C "$reponame" submodule init
+    git -C "$reponame" submodule update --remote
+  else
+    git clone --recurse-submodules --single-branch --branch "${branch}" https://github.com/greenpeace/"${reponame}"
+  fi
 
   npm ci --prefix "${reponame}" "${reponame}"
   NODE_OPTIONS=--max_old_space_size=1024 npm run-script --prefix "${reponame}" build

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -68,7 +68,7 @@ do
           echo "CIRCLE_PR_USERNAME: ${CIRCLE_PR_USERNAME}"
           echo "CIRCLE_PR_REPONAME: ${CIRCLE_PR_REPONAME}"
           tmp=$(mktemp)
-          jq ".repositories |= [{\"type\": \"vcs\", \"url\": \"git@github.com:${FORK_USER}/${FORK_REPO}.git\"}] + ." "$f" > "$tmp"
+          jq ".repositories |= [{\"type\": \"vcs\", \"url\": \"https://github.com/${FORK_USER}/${FORK_REPO}\"}] + ." "$f" > "$tmp"
           mv "$tmp" "$f"
         fi
       fi

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -62,13 +62,14 @@ do
         jq ".require.\"greenpeace/${reponame}\" = \"dev-${branch}\"" "$f" > "$tmp"
         mv "$tmp" "$f"
 
-        if [ -n "$FORK_USER" ]; then
+        if [ -n "$FORK_USER" ] && [ "$FORK_REPO" == "$reponame" ]; then
           echo "FORK_USER: ${FORK_USER}"
           echo "FORK_REPO: ${FORK_REPO}"
           echo "CIRCLE_PR_USERNAME: ${CIRCLE_PR_USERNAME}"
           echo "CIRCLE_PR_REPONAME: ${CIRCLE_PR_REPONAME}"
+
           tmp=$(mktemp)
-          jq ".repositories |= [{\"type\": \"vcs\", \"url\": \"https://github.com/${FORK_USER}/${FORK_REPO}\"}] + ." "$f" > "$tmp"
+          jq ".repositories |= [{\"type\": \"path\", \"url\": \"/home/circleci/theme-src\"}] + ." "$f" > "$tmp"
           mv "$tmp" "$f"
         fi
       fi

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -58,7 +58,19 @@ do
       if [ -e "$f" ]
       then
         echo " - $f"
-        sed -i "s|\"greenpeace\\/${reponame}\" \?: \".*\",|\"greenpeace\\/${reponame}\" : \"dev-${branch}\",|g" "${f}"
+        tmp=$(mktemp)
+        jq ".require.\"greenpeace/${reponame}\" = \"dev-${branch}\"" "$f" > "$tmp"
+        mv "$tmp" "$f"
+
+        if [ -n "$FORK_USER" ]; then
+          echo "FORK_USER: ${FORK_USER}"
+          echo "FORK_REPO: ${FORK_REPO}"
+          echo "CIRCLE_PR_USERNAME: ${CIRCLE_PR_USERNAME}"
+          echo "CIRCLE_PR_REPONAME: ${CIRCLE_PR_REPONAME}"
+          tmp=$(mktemp)
+          jq ".repositories |= [{\"type\": \"vcs\", \"url\": \"git@github.com:${FORK_USER}/${FORK_REPO}.git\"}] + ." "$f" > "$tmp"
+          mv "$tmp" "$f"
+        fi
       fi
     done
 


### PR DESCRIPTION
* Use jq instead of sed to handle substitution in json.
* If the a fork user was passed, add the fork repository to the
repositories. Else jobs running for a PR in a fork are not able to get
the code.