### PR TITLE
Planet 5322 add shfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.sh]
+indent_style = space
+indent_size = 2
+switch_case_indent = true

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,12 +10,11 @@
 # Workaround to make Docker happy on WSL
 docker ps >/dev/null || export DOCKER_HOST=tcp://localhost:2375
 
-if git rev-parse --verify HEAD >/dev/null 2>&1
-then
-	against=HEAD
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+  against=HEAD
 else
-	# Initial commit: diff against an empty tree object
-	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+  # Initial commit: diff against an empty tree object
+  against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
 # If you want to allow non-ASCII filenames set this variable to true.
@@ -28,13 +27,12 @@ exec 1>&2
 # them from being added to the repository. We exploit the fact that the
 # printable range starts at the space character and ends with tilde.
 if [ "$allownonascii" != "true" ] &&
-	# Note that the use of brackets around a tr range is ok here, (it's
-	# even required, for portability to Solaris 10's /usr/bin/tr), since
-	# the square bracket bytes happen to fall in the designated range.
-	test $(git diff --cached --name-only --diff-filter=A -z $against |
-	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
-then
-	cat <<\EOF
+  # Note that the use of brackets around a tr range is ok here, (it's
+  # even required, for portability to Solaris 10's /usr/bin/tr), since
+  # the square bracket bytes happen to fall in the designated range.
+  test $(git diff --cached --name-only --diff-filter=A -z $against |
+    LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0; then
+  cat <<\EOF
 Error: Attempt to add a non-ASCII file name.
 
 This can cause problems if you want to work with people on other platforms.
@@ -45,7 +43,7 @@ If you know what you are doing you can disable this check using:
 
   git config hooks.allownonascii true
 EOF
-	exit 1
+  exit 1
 fi
 
 make -j lint || exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -30,8 +30,8 @@ if [ "$allownonascii" != "true" ] &&
   # Note that the use of brackets around a tr range is ok here, (it's
   # even required, for portability to Solaris 10's /usr/bin/tr), since
   # the square bracket bytes happen to fall in the designated range.
-  test $(git diff --cached --name-only --diff-filter=A -z $against |
-    LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0; then
+  test "$(git diff --cached --name-only --diff-filter=A -z $against |
+    LC_ALL=C tr -d '[ -~]\0' | wc -c)" != 0; then
   cat <<\EOF
 Error: Attempt to add a non-ASCII file name.
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ DOCKER := $(shell command -v docker 2> /dev/null)
 COMPOSER := $(shell command -v composer 2> /dev/null)
 JQ := $(shell command -v jq 2> /dev/null)
 SHELLCHECK := $(shell command -v shellcheck 2> /dev/null)
+SHFMT := $(shell command -v shfmt 2> /dev/null)
 YAMLLINT := $(shell command -v yamllint 2> /dev/null)
 
 # ============================================================================
@@ -74,6 +75,10 @@ ifndef SHELLCHECK
 $(error "shellcheck is not installed: https://github.com/koalaman/shellcheck")
 endif
 	@find . -type f -name '*.sh' | xargs shellcheck
+ifndef SHFMT
+$(error "shfmt is not installed: https://github.com/mvdan/sh")
+endif
+	@shfmt -i 2 -ci -d .
 
 lint-yaml:
 ifndef YAMLLINT

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,14 @@ init: .git/hooks/pre-commit
 clean:
 	rm -f src/Dockerfile
 
+format: format-sh
+
+format-sh:
+ifndef SHFMT
+$(error "shfmt is not installed: https://github.com/mvdan/sh")
+endif
+	@shfmt -i 2 -ci -w .
+
 lint: init lint-sh lint-yaml lint-json lint-composer lint-docker lint-ci
 
 lint-sh:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ format: format-sh
 
 format-sh:
 ifndef SHFMT
-$(error "shfmt is not installed: https://github.com/mvdan/sh")
+	$(error "shfmt is not installed: https://github.com/mvdan/sh")
 endif
 	@shfmt -i 2 -ci -w .
 
@@ -80,10 +80,10 @@ lint: init lint-sh lint-yaml lint-json lint-composer lint-docker lint-ci
 
 lint-sh:
 ifndef SHELLCHECK
-$(error "shellcheck is not installed: https://github.com/koalaman/shellcheck")
+	$(error "shellcheck is not installed: https://github.com/koalaman/shellcheck")
 endif
 ifndef SHFMT
-$(error "shfmt is not installed: https://github.com/mvdan/sh")
+	$(error "shfmt is not installed: https://github.com/mvdan/sh")
 endif
 	@shfmt -f . | xargs shellcheck
 	@shfmt -i 2 -ci -d .

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ lint-sh:
 ifndef SHELLCHECK
 $(error "shellcheck is not installed: https://github.com/koalaman/shellcheck")
 endif
-	@find . -type f -name '*.sh' | xargs shellcheck
 ifndef SHFMT
 $(error "shfmt is not installed: https://github.com/mvdan/sh")
 endif
+	@shfmt -f . | xargs shellcheck
 	@shfmt -i 2 -ci -d .
 
 lint-yaml:

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Run `make init` after cloning to ensure you have the pre-commit hooks installed.
 4. yamllint
 5. circleci
 6. composer
+7. shfmt

--- a/src/activate_plugins.sh
+++ b/src/activate_plugins.sh
@@ -13,13 +13,11 @@ main() {
     -l "release=${HELM_RELEASE},component=php" \
     -o jsonpath="{.items[-1:].metadata.name}")
 
-  if [[ -z "$php" ]]
-  then
-    >&2 echo "ERROR: php pod not found in release ${HELM_RELEASE}"
+  if [[ -z "$php" ]]; then
+    echo >&2 "ERROR: php pod not found in release ${HELM_RELEASE}"
   fi
 
-  if kubectl exec -n "${HELM_NAMESPACE}" "$php" -- wp plugin activate --all
-  then
+  if kubectl exec -n "${HELM_NAMESPACE}" "$php" -- wp plugin activate --all; then
     return 0
   fi
 
@@ -28,5 +26,5 @@ main() {
 
 retry main && exit 0
 
->&2 echo "FAILED"
+echo >&2 "FAILED"
 exit 1

--- a/src/bake.sh
+++ b/src/bake.sh
@@ -45,22 +45,19 @@ sleep 20
 
 proxy_container=$(docker-compose -p build ps -q app)
 
-until [[ $success -ge $threshold ]]
-do
+until [[ $success -ge $threshold ]]; do
   # Curl to container and expect status code 200
-  if docker run --network "container:$proxy_container" --rm appropriate/curl -s -k "http://localhost:80" | grep -s "greenpeace" > /dev/null
-  then
-    success=$((success+1))
+  if docker run --network "container:$proxy_container" --rm appropriate/curl -s -k "http://localhost:80" | grep -s "greenpeace" >/dev/null; then
+    success=$((success + 1))
     echo "Success: $success/$threshold"
   else
     success=0
   fi
 
-  loop=$((loop-1))
-  if [[ $loop -lt 1 ]]
-  then
-    >&2 echo "[ERROR] Timeout waiting for docker-compose to start"
-    >&2 docker-compose -p build logs
+  loop=$((loop - 1))
+  if [[ $loop -lt 1 ]]; then
+    echo >&2 "[ERROR] Timeout waiting for docker-compose to start"
+    docker-compose >&2 -p build logs
     exit 1
   fi
 
@@ -94,9 +91,8 @@ numfiles=${#files[@]}
 
 echo "$numfiles files in source/public"
 
-if [[ $numfiles -lt 3 ]]
-then
-  >&2 echo "ERROR not enough files for a success"
+if [[ $numfiles -lt 3 ]]; then
+  echo >&2 "ERROR not enough files for a success"
   ls source/public
   exit 1
 fi
@@ -106,8 +102,7 @@ rm -f source/public/index.html
 
 # Tagged releases are production, remove the robots.txt
 # FIXME Find a better way to handle robots.txt
-if [[ -n "${CIRCLE_TAG:-}" ]]
-then
+if [[ -n "${CIRCLE_TAG:-}" ]]; then
   rm -f source/public/robots.txt
 fi
 

--- a/src/checkout.sh
+++ b/src/checkout.sh
@@ -3,8 +3,7 @@ set -ex
 
 # Workaround old docker images with incorrect $HOME
 # check https://github.com/docker/docker/issues/2968 for details
-if [ "${HOME}" = "/" ]
-then
+if [ "${HOME}" = "/" ]; then
   HOME=$(getent passwd "$(id -un)" | cut -d: -f6)
   export HOME
 fi
@@ -13,11 +12,15 @@ mkdir -p ~/.ssh
 
 echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
-' >> ~/.ssh/known_hosts
+' >>~/.ssh/known_hosts
 
-(umask 077; touch ~/.ssh/id_rsa)
+(
+  umask 077
+  touch ~/.ssh/id_rsa
+)
 chmod 0600 ~/.ssh/id_rsa
-(cat <<EOF > ~/.ssh/id_rsa
+(
+  cat <<EOF >~/.ssh/id_rsa
 $CHECKOUT_KEY
 EOF
 )
@@ -25,8 +28,7 @@ EOF
 # use git+ssh instead of https
 git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
 
-if [ -e /home/circleci/source/.git ]
-then
+if [ -e /home/circleci/source/.git ]; then
   echo "WARNING: source directory is already a Git repository: /home/circleci/source"
   cd /home/circleci/source
   git remote set-url origin "$GIT_SOURCE" || true
@@ -45,9 +47,7 @@ ls -al
 
 ################################################################################
 
-
-if [ -e /home/circleci/merge/.git ]
-then
+if [ -e /home/circleci/merge/.git ]; then
   echo "WARNING: merge directory is already a Git repository: /home/circleci/merge"
   cd /home/circleci/merge
   git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true

--- a/src/configure_redis.sh
+++ b/src/configure_redis.sh
@@ -15,9 +15,8 @@ main() {
     -l "release=${HELM_RELEASE},component=php" \
     -o jsonpath="{.items[-1:].metadata.name}")
 
-  if [[ -z "$pod" ]]
-  then
-    >&2 echo "ERROR: php pod not found in release ${HELM_RELEASE}"
+  if [[ -z "$pod" ]]; then
+    echo >&2 "ERROR: php pod not found in release ${HELM_RELEASE}"
     return 1
   fi
 
@@ -25,10 +24,8 @@ main() {
     -l "app=redis,release=${HELM_RELEASE}" \
     -o jsonpath="{.items[0].metadata.name}")
 
-
-  if [[ -z "$redis_service" ]]
-  then
-    >&2 echo "ERROR: redis service not found in release ${HELM_RELEASE}"
+  if [[ -z "$redis_service" ]]; then
+    echo >&2 "ERROR: redis service not found in release ${HELM_RELEASE}"
     return 1
   fi
 
@@ -40,8 +37,7 @@ main() {
   echo ""
 
   if kubectl -n "${HELM_NAMESPACE}" exec "$pod" -- \
-    wp option patch update rt_wp_nginx_helper_options redis_hostname "$redis_service"
-  then
+    wp option patch update rt_wp_nginx_helper_options redis_hostname "$redis_service"; then
     return 0
   fi
 
@@ -51,5 +47,5 @@ main() {
 
 retry main && exit 0
 
->&2 echo "FAILED"
+echo >&2 "FAILED"
 exit 1

--- a/src/helm_confirm.sh
+++ b/src/helm_confirm.sh
@@ -3,8 +3,7 @@ set -eu
 
 release_status=$(helm status "${HELM_RELEASE}" -o json | jq '.info.status.code')
 
-if [[ ${release_status} = "1" ]]
-then
+if [[ ${release_status} = "1" ]]; then
   echo "Helm release ${HELM_RELEASE} successful"
   TYPE="Helm Deployment" EXTRA_TEXT="\`\`\`History:
 $(helm history "${HELM_RELEASE}" --max=5)

--- a/src/helm_deploy.sh
+++ b/src/helm_deploy.sh
@@ -4,7 +4,6 @@ set -uo pipefail
 # shellcheck disable=SC1091
 . lib/retry.sh
 
-
 function install() {
 
   if helm upgrade --install --force --wait --timeout 300 "${HELM_RELEASE}" \
@@ -12,15 +11,14 @@ function install() {
     --values values.yaml \
     --values secrets.yaml \
     --version "${CHART_VERSION}" \
-  p4/wordpress 2>&1 | tee -a helm_output.txt
-  then
+    p4/wordpress 2>&1 | tee -a helm_output.txt; then
     echo "SUCCESS: Deployed release $HELM_RELEASE"
     return 0
   fi
   echo "FAILURE: Could not deploy release $HELM_RELEASE"
 
-  if grep -q "kind Service with the name \"${HELM_RELEASE}-redis-headless\" already exists in the cluster and wasn't defined in the previous release" helm_output.txt;
-  then kubectl -n "${HELM_NAMESPACE}" delete svc "${HELM_RELEASE}"-redis-headless
+  if grep -q "kind Service with the name \"${HELM_RELEASE}-redis-headless\" already exists in the cluster and wasn't defined in the previous release" helm_output.txt; then
+    kubectl -n "${HELM_NAMESPACE}" delete svc "${HELM_RELEASE}"-redis-headless
   fi
 
   return 1
@@ -31,25 +29,25 @@ echo
 
 # Create Helm deploy secrets file from environment
 # FIXME: generate this in ramfs
-envsubst < secrets.yaml.in > secrets.yaml
+envsubst <secrets.yaml.in >secrets.yaml
 
 # Create values file
-envsubst < values.yaml.in > values.yaml
+envsubst <values.yaml.in >values.yaml
 cat values.yaml
 
 TIMEOUT=10 retry install && exit 0
 
->&2 echo "ERROR: Helm release ${HELM_RELEASE} failed to deploy"
+echo >&2 "ERROR: Helm release ${HELM_RELEASE} failed to deploy"
 
 TYPE="Helm Deployment" \
-EXTRA_TEXT="\`\`\`
+  EXTRA_TEXT="\`\`\`
 History:
 $(helm history "${HELM_RELEASE}" --max=5)
 
 Build:
 $(cat helm_output.txt)
 \`\`\`" \
-notify-job-failure.sh
+  notify-job-failure.sh
 
 ./helm_rollback.sh
 

--- a/src/helm_prepare.sh
+++ b/src/helm_prepare.sh
@@ -3,16 +3,14 @@ set -eu
 
 release_exists=$(helm list -q | grep -w "${HELM_RELEASE}" | xargs)
 
-if [[ -z "$release_exists" ]]
-then
+if [[ -z "$release_exists" ]]; then
   echo "Helm: ${HELM_RELEASE} does not exist: first deploy"
   exit 0
 fi
 
 release_status=$(helm status "${HELM_RELEASE}" -o json | jq '.info.status.code' | xargs)
 
-if [[ $release_status = "1" ]]
-then
+if [[ $release_status = "1" ]]; then
   echo "Helm: ${HELM_RELEASE} is in a good state"
   exit 0
 fi

--- a/src/helm_rollback.sh
+++ b/src/helm_rollback.sh
@@ -7,20 +7,19 @@ set -euo pipefail
 release=${1:-${HELM_RELEASE}}
 helm history "$release" --max=10
 
-helm get "$release" > helm_get_release.txt
+helm get "$release" >helm_get_release.txt
 current=$(grep '^REVISION:' helm_get_release.txt | cut -d' ' -f2)
 
 re='^[0-9]+$'
-if ! [[ $current =~ $re ]] ; then
-   >&2 echo "ERROR: Revision is not a number: $current"
-   exit 1
+if ! [[ $current =~ $re ]]; then
+  echo >&2 "ERROR: Revision is not a number: $current"
+  exit 1
 fi
 
 helm status "$release" | tee helm_release_status.txt
 
-if [[ $current -eq 1 ]]
-then
-  >&2 echo "ERROR: $release is first revision, cannot perform helm rollback"
+if [[ $current -eq 1 ]]; then
+  echo >&2 "ERROR: $release is first revision, cannot perform helm rollback"
   exit 1
 fi
 
@@ -28,48 +27,46 @@ status=$(grep '^STATUS:' helm_release_status.txt | cut -d' ' -f2)
 echo "Release #current of $release is in state: $status"
 
 # Find last good deployment
-previous=${2:-$(( current - 1 ))}
-while [[ $previous -gt 0 ]]
-do
-  [[ $(helm status "$release" --revision "$previous" | grep '^STATUS:' | cut -d' ' -f2 | xargs) == "SUPERSEDED"  ]] && break
-  previous=$(( previous - 1 ))
+previous=${2:-$((current - 1))}
+while [[ $previous -gt 0 ]]; do
+  [[ $(helm status "$release" --revision "$previous" | grep '^STATUS:' | cut -d' ' -f2 | xargs) == "SUPERSEDED" ]] && break
+  previous=$((previous - 1))
 done
 
 # Nothing found, exit with error
-[[ $previous -lt 1 ]] && >&2 echo "ERROR: No good releases to roll back to!" && exit 1
+[[ $previous -lt 1 ]] && echo >&2 "ERROR: No good releases to roll back to!" && exit 1
 
 # Success
 function rollback() {
   echo "Rolling back $release to revision: $previous"
 
   # Perform rollback
-  if helm rollback "$release" "$previous"
-  then
+  if helm rollback "$release" "$previous"; then
     echo "SUCCESS: Release $release now at revision: $previous"
     TYPE="Helm Rollback" \
-    EXTRA_TEXT="\`\`\`
+      EXTRA_TEXT="\`\`\`
     History:
     $(helm history "${HELM_RELEASE}" --max=5)
     \`\`\`" \
-    notify-job-success.sh
+      notify-job-success.sh
 
     return 0
   fi
 
-  >&2 echo "ERROR: Failed to rollback $release to revision: $previous"
+  echo >&2 "ERROR: Failed to rollback $release to revision: $previous"
   return 1
 }
 
 retry rollback && exit 0
 
->&2 echo "ERROR: Failed during rollback"
+echo >&2 "ERROR: Failed during rollback"
 helm status "$release
 "
 TYPE="Helm Rollback" \
-EXTRA_TEXT="\`\`\`
+  EXTRA_TEXT="\`\`\`
 History:
 $(helm history "${HELM_RELEASE}" --max=5)
 \`\`\`" \
-notify-job-failure.sh
+  notify-job-failure.sh
 
 exit 1

--- a/src/lib/retry.sh
+++ b/src/lib/retry.sh
@@ -7,14 +7,13 @@ set -euo pipefail
 # timeout is given by TIMEOUT in seconds (default 1.)
 #
 # Successive backoffs double the timeout.
-function retry {
+function retry() {
   local max_attempts=${ATTEMPTS:-5}
   local timeout=${TIMEOUT:-1}
   local attempt=1
   local exitCode
 
-  while (( attempt <= max_attempts ))
-  do
+  while ((attempt <= max_attempts)); do
     set +e
     "$@"
     exitCode=$?
@@ -22,16 +21,16 @@ function retry {
 
     [ $exitCode -eq 0 ] && return 0
 
-    >&2 printf "Attempt #%d/%d failed. " "$attempt" "$max_attempts"
-    attempt=$(( attempt + 1 ))
-    (( attempt > max_attempts )) && break
+    printf >&2 "Attempt #%d/%d failed. " "$attempt" "$max_attempts"
+    attempt=$((attempt + 1))
+    ((attempt > max_attempts)) && break
 
     echo "Retrying in $timeout seconds ..."
     sleep "$timeout"
-    timeout=$(( timeout * 2 ))
+    timeout=$((timeout * 2))
   done
 
-  >&2 echo "You've failed me for the last time! ($*)"
+  echo >&2 "You've failed me for the last time! ($*)"
 
   return $exitCode
 }

--- a/src/newrelic_deployment.sh
+++ b/src/newrelic_deployment.sh
@@ -14,7 +14,7 @@ json=$(jq -n \
   --arg CHANGELOG "$changelog" \
   --arg DESCRIPTION "$description" \
   --arg USER "$user" \
-'{
+  '{
   "deployment": {
     "revision": $REVISION,
     "changelog": $CHANGELOG,

--- a/src/notify-sync-admins.sh
+++ b/src/notify-sync-admins.sh
@@ -6,35 +6,29 @@ MSG_BODY="Hi there,<br><br>You receive this email because you are an administrat
 EMAIL_FROM="$RELEASE_EMAIL_FROM"
 GCLOUD_ZONE=us-central1-a
 
-
 gcloud container clusters get-credentials "${GCLOUD_CLUSTER}" \
---zone "${GCLOUD_ZONE}" \
---project "${GOOGLE_PROJECT_ID}"
-
+  --zone "${GCLOUD_ZONE}" \
+  --project "${GOOGLE_PROJECT_ID}"
 
 php=$(kubectl get pods --namespace "${HELM_NAMESPACE}" \
-    --sort-by=.metadata.creationTimestamp \
-    --field-selector=status.phase=Running \
-    -l "release=${HELM_RELEASE},component=php" \
-    -o jsonpath="{.items[-1:].metadata.name}")
+  --sort-by=.metadata.creationTimestamp \
+  --field-selector=status.phase=Running \
+  -l "release=${HELM_RELEASE},component=php" \
+  -o jsonpath="{.items[-1:].metadata.name}")
 
-if [[ -z "$php" ]]
-then
+if [[ -z "$php" ]]; then
   echo "ERROR: PHP pod not found!"
   exit 1
 fi
 
 EMAIL_ADDRESS=$(kubectl --namespace "${HELM_NAMESPACE}" exec "$php" wp option get admin_email)
 
-
-
-
 json=$(jq -n \
   --arg EMAIL_FROM "$EMAIL_FROM" \
   --arg EMAIL_ADDRESS "$EMAIL_ADDRESS" \
   --arg MSG_SUBJECT "$MSG_SUBJECT" \
   --arg MSG_BODY "$MSG_BODY" \
-'{
+  '{
   "personalizations": [
     {
       "to": [

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -29,11 +29,11 @@ build_assets() {
   npm ci --prefix "${reponame}" "${reponame}"
   npm run-script --prefix "${reponame}" build
 
-  if [[ "${reponame}" == *theme ]]; then \
-      subdir="themes"; \
-  else \
-      subdir="plugins"; \
-  fi; \
+  if [[ "${reponame}" == *theme ]]; then
+    subdir="themes"
+  else
+    subdir="plugins"
+  fi
 
   buildDir="${built_assets_dir}/public/wp-content/${subdir}/${reponame}/assets/build/"
   mkdir -p "${buildDir}"
@@ -41,9 +41,8 @@ build_assets() {
   rm -rf "${reponame}"
 }
 
-for plugin_branch_env_var in "${plugin_branch_env_vars[@]}"
-do
-  reponame=planet4-$( echo "${plugin_branch_env_var%_*}" | tr '[:upper:]' '[:lower:]' | sed 's/_/-/g')
+for plugin_branch_env_var in "${plugin_branch_env_vars[@]}"; do
+  reponame=planet4-$(echo "${plugin_branch_env_var%_*}" | tr '[:upper:]' '[:lower:]' | sed 's/_/-/g')
   composer_dev_prefix="dev-"
   # temp solution to remove it and add it again where it is needed. It would be better if this script got branchname
   # without dev- before it, so stripping it as the first thing allows us to change that
@@ -51,10 +50,8 @@ do
 
   if [ -n "${!plugin_branch_env_var}" ]; then
     echo "Replacing ${reponame} with branch ${branch} from environment variable"
-    for f in "${composer_files[@]}"
-    do
-      if [ -e "$f" ]
-      then
+    for f in "${composer_files[@]}"; do
+      if [ -e "$f" ]; then
         echo " - $f"
         sed -i "s|\"greenpeace\\/${reponame}\" \?: \".*\",|\"greenpeace\\/${reponame}\" : \"dev-${branch}\",|g" "${f}"
       fi
@@ -70,11 +67,10 @@ do
   repo_branch=""
 
   # now go throuhg the composer file and see if there are any dev branches for planet4 plugins or theme
-  for f in "${composer_files[@]}"
-  do
+  for f in "${composer_files[@]}"; do
     if [ -e "$f" ]; then
       json_path=".require.\"greenpeace/${reponame}\""
-      plugin_version=$(jq -r "${json_path} // empty" < "${f}")
+      plugin_version=$(jq -r "${json_path} // empty" <"${f}")
       branch=${plugin_version#"$composer_dev_prefix"}
 
       if [ -n "$branch" ]; then

--- a/src/rewrite_dockerfiles.sh
+++ b/src/rewrite_dockerfiles.sh
@@ -15,8 +15,7 @@ export SOURCE_PATH=/app/source
 # )
 # envvars_string="$(printf "%s:" "${envvars[@]}")"
 
-for i in build app openresty
-do
+for i in build app openresty; do
   build_dir=$i
-  envsubst < "${build_dir}/Dockerfile.in" > "${build_dir}/Dockerfile"
+  envsubst <"${build_dir}/Dockerfile.in" >"${build_dir}/Dockerfile"
 done

--- a/src/run_bash_script_in_php_pod.sh
+++ b/src/run_bash_script_in_php_pod.sh
@@ -6,9 +6,8 @@ external_script=$1
 base_external_script=$(basename "$external_script")
 shift
 
-if [[ ! -e "$external_script" ]]
-then
-  >&2 echo "ERROR: file does not exist: '$1'"
+if [[ ! -e "$external_script" ]]; then
+  echo >&2 "ERROR: file does not exist: '$1'"
   exit 1
 fi
 
@@ -18,9 +17,8 @@ php=$(kubectl get pods --namespace "${HELM_NAMESPACE}" \
   -l "release=${HELM_RELEASE},component=php" \
   -o jsonpath="{.items[-1:].metadata.name}")
 
-if [[ -z "$php" ]]
-then
-  >&2 echo "ERROR: php pod not found in release ${HELM_RELEASE}"
+if [[ -z "$php" ]]; then
+  echo >&2 "ERROR: php pod not found in release ${HELM_RELEASE}"
   exit 1
 fi
 

--- a/src/run_post_deploy_scripts.sh
+++ b/src/run_post_deploy_scripts.sh
@@ -9,10 +9,9 @@ workspace=/tmp/workspace/src
   exit 0
 }
 
-for file in "$workspace"/tasks/post-deploy/*
-do
-    echo ""
-    echo "Running the script : $(basename "$file")"
-    echo ""
-    ./run_bash_script_in_php_pod.sh "$file"
+for file in "$workspace"/tasks/post-deploy/*; do
+  echo ""
+  echo "Running the script : $(basename "$file")"
+  echo ""
+  ./run_bash_script_in_php_pod.sh "$file"
 done

--- a/src/sql_create_sync_file.sh
+++ b/src/sql_create_sync_file.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-function finish {
+function finish() {
   # Stop background jobs
   kill "$(jobs -p)"
 }
@@ -11,8 +11,7 @@ WP_DB_PASSWORD_DC=$(echo "${WP_DB_PASSWORD}" | base64 -d)
 BUCKET_DESTINATION=gs://${CONTAINER_PREFIX}-source
 export GOOGLE_APPLICATION_CREDENTIALS="/tmp/workspace/src/key.json"
 
-if [ -z ${CIRCLE_TAG+x} ];
-then
+if [ -z ${CIRCLE_TAG+x} ]; then
   SQL_TAG=$(date +%Y-%m-%d)
 else
   SQL_TAG=${CIRCLE_TAG}
@@ -38,7 +37,7 @@ mysqldump -v \
   -u "$WP_DB_USERNAME_DC" \
   -p"$WP_DB_PASSWORD_DC" \
   -h 127.0.0.1 \
-  "${WP_DB_NAME}" > "content/${WP_DB_NAME}-${SQL_TAG}.sql"
+  "${WP_DB_NAME}" >"content/${WP_DB_NAME}-${SQL_TAG}.sql"
 
 echo ""
 echo "gzip ..."
@@ -49,15 +48,13 @@ gzip --test "content/${WP_DB_NAME}-${SQL_TAG}.sql.gz"
 echo ""
 echo "Checking if bucket exists"
 echo ""
-if ! gsutil ls "${BUCKET_DESTINATION}/"
-then
+if ! gsutil ls "${BUCKET_DESTINATION}/"; then
   echo "Bucket does not exist, attempting to create it"
-  gsutil mb "${BUCKET_DESTINATION}/";
+  gsutil mb "${BUCKET_DESTINATION}/"
   echo "And now we will apply labels"
   gsutil label ch -l "nro:${APP_HOSTNAME}/${APP_HOSTPATH:-}" "${BUCKET_DESTINATION}"
   gsutil label ch -l "environment:${ENVIRONMENT}" "${BUCKET_DESTINATION}"
 fi
-
 
 echo ""
 echo "uploading to ${BUCKET_DESTINATION}/..."

--- a/src/sql_to_sync_site.sh
+++ b/src/sql_to_sync_site.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-function finish {
+function finish() {
   # Stop background jobs
   kill "$(jobs -p)"
 }
@@ -11,8 +11,7 @@ WP_DB_PASSWORD_DC=$(echo "${WP_DB_PASSWORD}" | base64 -d)
 SITE_ENV=$1
 CLOUDSQL_INSTANCE=${GOOGLE_PROJECT_ID}:us-central1:${CLOUDSQL_INSTANCE}
 export GOOGLE_APPLICATION_CREDENTIALS="/tmp/workspace/src/key.json"
-if [ -z ${CIRCLE_TAG+x} ];
-then
+if [ -z ${CIRCLE_TAG+x} ]; then
   SQL_TAG=$(date +%Y-%m-%d)
 else
   SQL_TAG=${CIRCLE_TAG}
@@ -27,7 +26,7 @@ echo ""
 echo ""
 echo "Creating the credential file for mysql"
 echo ""
-cat <<EOF > mysql.cnf
+cat <<EOF >mysql.cnf
 [client]
 user = ${WP_DB_USERNAME_DC}
 password = ${WP_DB_PASSWORD_DC}
@@ -41,7 +40,7 @@ cloud_sql_proxy \
 echo ""
 echo "Creating the credential file for mysql"
 echo ""
-cat <<EOF > mysql.cnf
+cat <<EOF >mysql.cnf
 [client]
 user = ${WP_DB_USERNAME_DC}
 password = ${WP_DB_PASSWORD_DC}
@@ -73,7 +72,7 @@ gunzip "content/${FILE_TO_IMPORT}.gz"
 echo ""
 echo "Importing the database to the ${WP_DB_TO_IMPORT_TO} database"
 echo ""
-mysql --defaults-extra-file="mysql.cnf" "${WP_DB_TO_IMPORT_TO}" < "content/${FILE_TO_IMPORT}"
+mysql --defaults-extra-file="mysql.cnf" "${WP_DB_TO_IMPORT_TO}" <"content/${FILE_TO_IMPORT}"
 
 echo ""
 echo "Get connected to gcloud"
@@ -110,17 +109,15 @@ echo "Replacing the path $OLD_PATH with $NEW_PATH for the images themselves"
 echo ""
 $kc exec "$POD" -- wp search-replace "$OLD_PATH" "$NEW_PATH" --precise --skip-columns=guid
 
-
 echo ""
 echo "Check if we are in an pathless environment"
 echo ""
-if [[ $APP_HOSTPATH == "<nil>" ]]
-then
-   OLD_PATH=$(yq -r .job_environments.production_environment.APP_HOSTNAME /tmp/workspace/src/.circleci/config.yml)
-   NEW_PATH=$(yq -r .job_environments."${SITE_ENV}"_environment.APP_HOSTNAME /tmp/workspace/src/.circleci/config.yml)
+if [[ $APP_HOSTPATH == "<nil>" ]]; then
+  OLD_PATH=$(yq -r .job_environments.production_environment.APP_HOSTNAME /tmp/workspace/src/.circleci/config.yml)
+  NEW_PATH=$(yq -r .job_environments."${SITE_ENV}"_environment.APP_HOSTNAME /tmp/workspace/src/.circleci/config.yml)
 else
-   OLD_PATH=$(yq -r .job_environments.production_environment.APP_HOSTNAME /tmp/workspace/src/.circleci/config.yml)/$APP_HOSTPATH
-   NEW_PATH=$(yq -r .job_environments."${SITE_ENV}"_environment.APP_HOSTNAME /tmp/workspace/src/.circleci/config.yml)/$APP_HOSTPATH
+  OLD_PATH=$(yq -r .job_environments.production_environment.APP_HOSTNAME /tmp/workspace/src/.circleci/config.yml)/$APP_HOSTPATH
+  NEW_PATH=$(yq -r .job_environments."${SITE_ENV}"_environment.APP_HOSTNAME /tmp/workspace/src/.circleci/config.yml)/$APP_HOSTPATH
 fi
 
 echo ""

--- a/src/sync_to_test_site.sh
+++ b/src/sync_to_test_site.sh
@@ -4,12 +4,11 @@ set -euo pipefail
 echo ""
 echo "Check if commit message requires Sync"
 GIT_COMMIT_MSG=$(git --git-dir=/tmp/workspace/src/.git log --format=%B -n 1 "$CIRCLE_SHA1")
-if [[ $GIT_COMMIT_MSG == *"[SYNC]"* ]]
-then
-    echo "Sync is required"
+if [[ $GIT_COMMIT_MSG == *"[SYNC]"* ]]; then
+  echo "Sync is required"
 else
-    echo "No Sync required. Exiting."
-    exit 0
+  echo "No Sync required. Exiting."
+  exit 0
 fi
 echo ""
 
@@ -48,7 +47,7 @@ echo ""
 echo "Generate the db dump"
 echo ""
 DB=$($kc exec "${POD}" -- wp db export --tables=wp_commentmeta,wp_comments,wp_postmeta,wp_posts,wp_termmeta,wp_terms,wp_term_relationships,wp_term_taxonomy --add-drop-table | cut -d' ' -f4 | sed -e "s/'\.//" -e "s/'//")
-$kc exec "${POD}" -- wp option get planet4_options --format=json > options.json
+$kc exec "${POD}" -- wp option get planet4_options --format=json >options.json
 FRONTPAGE=$($kc exec "${POD}" -- wp option get page_on_front)
 
 echo ""
@@ -83,16 +82,16 @@ echo "Importing the db file"
 echo ""
 $kc exec "${POD}" -- wp db import data.sql
 $kc exec "${POD}" -- wp option delete planet4_options
-$kc exec -i "${POD}" -- wp option add planet4_options --format=json < options.json
+$kc exec -i "${POD}" -- wp option add planet4_options --format=json <options.json
 $kc exec "${POD}" -- wp option update page_on_front "${FRONTPAGE}"
 $kc exec "${POD}" -- rm data.sql
 
 echo ""
 echo "Assign admin author to avoid orphan posts"
 echo ""
-$kc exec "${POD}" -- wp post list --post_type=post --field=ID --format=ids > posts.txt
-$kc exec "${POD}" -- wp post list --post_type=page --field=ID --format=ids > pages.txt
-$kc exec "${POD}" -- wp post list --post_type=campaign --field=ID --format=ids > campaigns.txt
+$kc exec "${POD}" -- wp post list --post_type=post --field=ID --format=ids >posts.txt
+$kc exec "${POD}" -- wp post list --post_type=page --field=ID --format=ids >pages.txt
+$kc exec "${POD}" -- wp post list --post_type=campaign --field=ID --format=ids >campaigns.txt
 $kc exec "${POD}" -- bash -c "wp post update $(cat campaigns.txt) --post_author=1"
 $kc exec "${POD}" -- bash -c "wp post update $(cat pages.txt) --post_author=1"
 $kc exec "${POD}" -- bash -c "wp post update $(cat posts.txt) --post_author=1"

--- a/src/use_release_branches.sh
+++ b/src/use_release_branches.sh
@@ -3,24 +3,21 @@ set -euo pipefail
 file="${1:-${HOME}/source/composer.json}"
 
 [ -e "$file" ] || {
-  >&2 echo "File not found: $file"
+  echo >&2 "File not found: $file"
   exit 1
 }
 
-if [ "$APP_ENVIRONMENT" == "staging" ]
-then
+if [ "$APP_ENVIRONMENT" == "staging" ]; then
   echo "The APP_ENVIRONMENT is $APP_ENVIRONMENT so we will pin greenpeace repos to their release branches"
   echo "---"
   echo
-  for i in $(jq -r '[.require | to_entries[] | select(.key | startswith("greenpeace")) ] | .[] | "\(.key):\(.value)"' "$file")
-  do
-    repo=${i//:*}
-    ver=${i//*:}
+  for i in $(jq -r '[.require | to_entries[] | select(.key | startswith("greenpeace")) ] | .[] | "\(.key):\(.value)"' "$file"); do
+    repo=${i//:*/}
+    ver=${i//*:/}
     printf "%s @ %s" "$repo" "$ver"
 
     release_branch=$(./latest_release_branch.sh "$repo")
-    if [ -n "$release_branch" ] && [[ $ver != "dev-$release_branch" ]]
-    then
+    if [ -n "$release_branch" ] && [[ $ver != "dev-$release_branch" ]]; then
       release_branch=dev-${release_branch}
       echo " => $release_branch"
       sed -i'.bckp' "s|\"${repo}\"*\".*\",|\"${repo}\" : \"${release_branch}\",|g" "$file"


### PR DESCRIPTION
This adds shfmt to the shellscript linting and all scrips in this repo have been auto-formatted.

I have added a `format` and `format-sh` target to the Makefile. Do we want to keep this?

Other than that I also used `shfmt -f .` to find files for `ShellCheck` since it can find files both based on filename and shebang (which now also includes the `.githooks/pre-commit` file in this repo).

Fixes greenpeace/planet4#72