### PR TITLE
PLANET-5407 Incease node memory limit

### DIFF
--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -29,7 +29,7 @@ build_assets() {
   git clone --recurse-submodules --single-branch --branch "${branch}" https://github.com/greenpeace/"${reponame}"
 
   npm ci --prefix "${reponame}" "${reponame}"
-  npm run-script --prefix "${reponame}" build
+  NODE_OPTIONS=--max_old_space_size=1024 npm run-script --prefix "${reponame}" build
 
   if [[ "${reponame}" == *theme ]]; then \
       subdir="themes"; \


### PR DESCRIPTION
`node` (and `npm`) have a default 512M memory limit in most environments. Doubling this limit to overcome often ENOMEM errors we get on build, probably due to constantly increasing our js codebase.

Here is a failed example (search for `ENOMEM`):
https://app.circleci.com/pipelines/github/greenpeace/planet4-plugin-gutenberg-blocks/2322/workflows/d4b99ff0-bb37-4969-9cbc-848fa5478415/jobs/6137

Here is a successful example with this change (search for `NODE_OPTIONS` inside the `Build containers` job):
https://app.circleci.com/pipelines/github/greenpeace/planet4-plugin-gutenberg-blocks/2324/workflows/706bb51d-3cc9-498b-b327-48084fc233db/jobs/6144
