### PR TITLE
Retry npm build on failure

### DIFF
--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -37,7 +37,7 @@ build_assets() {
   fi
 
   npm ci --prefix "${reponame}" "${reponame}"
-  NODE_OPTIONS=--max_old_space_size=2048 npm run-script --prefix "${reponame}" build
+  NODE_OPTIONS=--max_old_space_size=1024 npm run-script --prefix "${reponame}" build
 
   if [[ "${reponame}" == *theme ]]; then
     subdir="themes"

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -37,7 +37,10 @@ build_assets() {
   fi
 
   npm ci --prefix "${reponame}" "${reponame}"
-  NODE_OPTIONS=--max_old_space_size=1024 npm run-script --prefix "${reponame}" build
+  for i in {1..5}; do
+    echo "build attempt $i"
+    NODE_OPTIONS=--max_old_space_size=1024 npm run-script --prefix "${reponame}" build && break
+  done
 
   if [[ "${reponame}" == *theme ]]; then
     subdir="themes"


### PR DESCRIPTION
Also decreases npm mem limit to a more sane value. 2G of RAM actually trigger more failures, because of two processes running at the same time in a 4G instance.

Tested here, where npm fails but re-tries:
https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/341/workflows/7399bcab-0caf-4804-84aa-8525ccaf4321/jobs/960
(hint: search for `build attempt`)