### PR TITLE
Planet 5484 don't build assets for tags

### DIFF
--- a/src/build/Dockerfile.in
+++ b/src/build/Dockerfile.in
@@ -18,15 +18,20 @@ COPY . /app/
 
 WORKDIR /app/source
 
+RUN time composer -v update --lock --no-dev --no-ansi
+
+RUN time composer -v update --lock --no-dev --no-ansi
+
+RUN time composer -v install --no-dev --no-ansi --no-interaction
+
 RUN \
-    time composer -v update --lock --no-dev --no-ansi && \
-    time composer -v install --no-dev --no-ansi --no-interaction && \
     if [ -f "${SOURCE_PATH}/composer-local.json" ]; then \
       rm -f composer.lock; \
       time composer -v config --no-ansi extra.merge-plugin.require composer-local.json; \
-    fi && \
-    time composer -v update --lock --no-dev --no-ansi && \
-    time composer -v install --no-dev --no-ansi --no-interaction
+    fi
+RUN time composer -v update --lock --no-dev --no-ansi
+
+RUN time composer -v install --no-dev --no-ansi --no-interaction
 
 RUN \
     if [ -d ${SOURCE_PATH}/built-dev-assets/ ]; then \

--- a/src/build/Dockerfile.in
+++ b/src/build/Dockerfile.in
@@ -18,20 +18,18 @@ COPY . /app/
 
 WORKDIR /app/source
 
-RUN time composer -v update --lock --no-dev --no-ansi
+RUN time composer -v update --lock --no-dev --no-ansi --prefer-dist
 
-RUN time composer -v update --lock --no-dev --no-ansi
-
-RUN time composer -v install --no-dev --no-ansi --no-interaction
+RUN time composer -v install --no-dev --no-ansi --no-interaction --prefer-dist
 
 RUN \
     if [ -f "${SOURCE_PATH}/composer-local.json" ]; then \
       rm -f composer.lock; \
       time composer -v config --no-ansi extra.merge-plugin.require composer-local.json; \
     fi
-RUN time composer -v update --lock --no-dev --no-ansi
+RUN time composer -v update --lock --no-dev --no-ansi --prefer-dist
 
-RUN time composer -v install --no-dev --no-ansi --no-interaction
+RUN time composer -v install --no-dev --no-ansi --no-interaction --prefer-dist
 
 RUN \
     if [ -d ${SOURCE_PATH}/built-dev-assets/ ]; then \

--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -111,7 +111,10 @@ for plugin_branch_env_var in "${plugin_branch_env_vars[@]}"; do
     fi
   done
 
-  if [ -n "$repo_branch" ]; then
+  # We don't need to build the assets for tags anymore, as we made those work with github releases.
+  # Branches still need to be built at this point for now.
+  # We know if it's a branch when the prefix was present, so $branch should differ from $plugin_version only in that case.
+  if [ -n "$repo_branch" ] && [ "${branch}" != "${plugin_version}" ]; then
     echo "Building assets for ${reponame} at branch ${repo_branch}"
     time PS4="__$reponame: " build_assets "$repo_branch" "$reponame"
   fi


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5484

Don't build assets if we're on a tag. These will have a zip uploaded to the corresponding github release, which will be used by composer instead of the default files because we added a dependency on https://github.com/greenpeace/github-archive-installer.

In order to make that plugin work on the test instance I needed to modify the composer install and update commands. I couldn't find a reason why we would actually need to run composer 4 times, it's working by running only the last one. But I need to further investigate if this really produces the same behavior as before, as I guess there is a reason why it was run 4 times. EDIT: I kept the composer commands the way they were (except splitting them into multiple `RUN` commands). It turned out not to be needed for this PR and a bit too risky as there's many possible edge cases.

~~I also added a line to remove the cache of master theme, to ensure it fetches the zip file from github. I expect the plugin, which is very minimal, might not produce expected results combined with the prestissimo plugin we use, but still need to verify that.~~ This turned out not to be needed. Without removing the cache it does use the correct version, and it's even able to leverage the cache. If this would fail anyway in rare cases, we will easily catch it on staging as it will be broken in an obvious way (i.e. assets will be missing causing visual regressions on all pages).