### PR TITLE
Fix assets not building for dev sites

### DIFF
--- a/src/rewrite_app_repos.sh
+++ b/src/rewrite_app_repos.sh
@@ -110,7 +110,10 @@ for plugin_branch_env_var in "${plugin_branch_env_vars[@]}"; do
     # Branches still need to be built at this point for now.
     # We know if it's a branch when the prefix was present, so $branch should differ from $plugin_version only in that case.
     if [ "${branch}" == "${plugin_version}" ]; then
-      echo "Version ${plugin_version} for ${reponame} in ${f} is not a branch"
+      echo "Version ${plugin_version} for ${reponame} in ${f} is not a branch, no need to build."
+      # Empty $repo_branch in case a previous composer file had set it.
+      repo_branch=""
+      continue
     fi
 
     # Assets are not included in the repositories, so we need to build them here.


### PR DESCRIPTION
[This check](https://github.com/greenpeace/planet4-builder/compare/better-asset-build-output?expand=1#diff-977f550fdc3a10875108491b359854ecbe7bbc2301dcaf0688f3f1b7d9e3dc40L117) was behaving incorrectly for dev sites: the branches defined in base-fork were not being built because the 2 variables that were being compared were both emptied if any subsequent file didn't require the repository.

Instead I moved the check to the loop, so that `$repo_branch` only exists if the last occurrence of the repository is a branch. If a branch is encountered, but a subsequent file has a tag, it will empty the variable to prevent building the branch.

I also flattened the structure a bit to make it more readable, and added some additional logging.