### PR TITLE
rsync the built files too before building openresty

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -222,6 +222,7 @@ build-openresty:
 	./rewrite_dockerfiles.sh
 	mkdir -p openresty/source/public
 	rsync -a --delete source/public/ openresty/source/public
+	rsync -av source/built-dev-assets/public openresty/source
 	source ./lib/retry.sh && \
 	retry docker pull gcr.io/planet-4-151612/openresty:$(PARENT_VERSION) && \
 	pushd openresty && \


### PR DESCRIPTION
Done a little differently than for the wordpress image, as there is already an rsync before the build, so we can do the rsync here to already put the built assets in place before the docker build.

Example build: https://app.circleci.com/pipelines/github/greenpeace/planet4-test-janus/12/workflows/dcb5c6ee-313b-4a7a-bdb8-2a06378e2849/jobs/51