### PR TITLE
Use target branch if i'ts a merge commit

### DIFF
--- a/src/trigger_test_instance.sh
+++ b/src/trigger_test_instance.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 repo=$1
+is_merge_commit=$2
 
 if [ -z "$repo" ]; then
   echo "Repository name required."
@@ -20,17 +21,22 @@ git clone "https://github.com/greenpeace/$instance_repo"
 
 composer_file="$instance_repo/composer-local.json"
 
-zip_url="https://storage.googleapis.com/$(cat /tmp/workspace/zip-path)"
-
-composer_json=$(jq '{name,type,autoload,extra}' </tmp/workspace/composer.json |
-  jq '.version = 7' |
-  jq ".dist = {type: \"zip\", url: \"$zip_url\"}")
-
-package_repo="{type: \"package\", package: $composer_json}"
-
 get_other_repos=".repositories // [] | map(select( .package.name != \"greenpeace/$repo\" ))"
 
 other_repos=$(jq "$get_other_repos" <"$composer_file")
+
+if [ "$is_merge_commit" == true ]; then
+  # If the workflow is running for a merge commit, we set the version to the branch that was merged to (master mostly).
+  version="dev-$CIRCLE_BRANCH"
+  package_repo=""
+else
+  version="7"
+  zip_url="https://storage.googleapis.com/$(cat /tmp/workspace/zip-path)"
+  composer_json=$(jq '{name,type,autoload,extra}' </tmp/workspace/composer.json |
+    jq ".version = $version" |
+    jq ".dist = {type: \"zip\", url: \"$zip_url\"}")
+  package_repo="{type: \"package\", package: $composer_json}"
+fi
 
 # This is needed since using cat directly when piping to the same file doesn't work here, resulted in a empty file.
 orig_json=$(cat "$composer_file")
@@ -38,7 +44,7 @@ orig_json=$(cat "$composer_file")
 echo "$orig_json" |
   jq ".repositories = $other_repos" |
   jq ".repositories += [$package_repo]" |
-  jq --tab ".require.\"greenpeace/$repo\" = \"7\"" >"$composer_file"
+  jq --tab ".require.\"greenpeace/$repo\" = \"$version\"" >"$composer_file"
 
 git -C "$instance_repo" --no-pager diff
 


### PR DESCRIPTION
This should clean up the repo definition and reset to `dev-master` if that is provided as an argument to the script.