### PR TITLE
Fix serialize error at log dump

### DIFF
--- a/src/book-test-instance.py
+++ b/src/book-test-instance.py
@@ -159,7 +159,7 @@ def transition_issue(jira_issue):
                              })
 
     vprint('Transitioned issue, response: ');
-    vprint(response, response.text, response.headers)
+    vprint(response.status_code, response.headers, response.text)
 
     failed = api_failed(response, transition_endpoint, exit_on_error=False)
     if failed:
@@ -285,7 +285,7 @@ def api_failed(response, endpoint, exit_on_error=True):
         return False
 
     vprint('API call failed')
-    vprint(response, response.text, response.headers)
+    vprint(response.status_code, response.headers, response.text)
     if exit_on_error:
         raise Exception("Status code {0} calling {1}".format(
             response.status_code, endpoint))


### PR DESCRIPTION
[This error](
https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/2599/workflows/9e96e88e-0c0e-4e59-96b6-6c31d19aa537/jobs/13300) happens when trying to write in logs an object Response 204

```
Traceback (most recent call last):
  File "/home/circleci/book-test-instance.py", line 406, in <module>
    }, results_file)
  File "/home/circleci/book-test-instance.py", line 327, in save_results
    json.dump(results, results_file, indent=2)
  File "/usr/lib/python2.7/json/__init__.py", line 189, in dump
    for chunk in iterable:
  File "/usr/lib/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 332, in _iterencode_list
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/usr/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <Response [204]> is not JSON serializable
```
Fix by removing full response object log and logging status_code instead (+ headers + text)