### PR TITLE
PLANET-5946 Add also extra environment requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ JQ := $(shell command -v jq 2> /dev/null)
 SHELLCHECK := $(shell command -v shellcheck 2> /dev/null)
 SHFMT := $(shell command -v shfmt 2> /dev/null)
 YAMLLINT := $(shell command -v yamllint 2> /dev/null)
+FLAKE8 := $(shell command -v flake8 2> /dev/null)
 
 # ============================================================================
 
@@ -69,7 +70,7 @@ ifndef SHFMT
 endif
 	@shfmt -i 2 -ci -w .
 
-lint: init lint-sh lint-yaml lint-json lint-composer lint-docker
+lint: init lint-sh lint-py lint-yaml lint-json lint-composer lint-docker
 
 lint-sh:
 ifndef SHELLCHECK
@@ -80,6 +81,12 @@ ifndef SHFMT
 endif
 	@shfmt -f . | xargs shellcheck
 	@shfmt -i 2 -ci -d .
+
+lint-py:
+ifndef FLAKE8
+	$(error "flake8 is not installed: https://pypi.org/project/flake8/")
+endif
+	@flake8
 
 lint-yaml:
 ifndef YAMLLINT

--- a/src/bin/book-test-instance.py
+++ b/src/bin/book-test-instance.py
@@ -6,10 +6,8 @@ import requests
 from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth1
 from oauthlib.oauth1 import SIGNATURE_RSA
-import sys
 import re
 import argparse
-import tempfile
 import hashlib
 
 
@@ -81,7 +79,8 @@ def get_jira_issue(pr=None, jira_key=None):
         'title': issue['fields']['summary'],
         'state': issue['fields']['status']['name'],
         'assignee': issue['fields']['assignee']['name'] if issue['fields']['assignee'] else None,
-        'test_instance': issue['fields'][JIRA_INSTANCE_FIELD][0]['value'] if issue['fields'][JIRA_INSTANCE_FIELD] else None,
+        'test_instance': (issue['fields'][JIRA_INSTANCE_FIELD][0]['value']
+                          if issue['fields'][JIRA_INSTANCE_FIELD] else None),
     }
 
 
@@ -348,7 +347,8 @@ if __name__ == '__main__':
     parser.add_argument("--no-booking", action="store_true",
                         help="Disable instance booking action")
     parser.add_argument("--results", default="booking-results.json",
-                        help="Save result in json to the specified file (default booking-results.json)")
+                        help=("Save result in json to the specified file "
+                              "(default booking-results.json)"))
     args = parser.parse_args()
 
     # Parsed options
@@ -359,6 +359,7 @@ if __name__ == '__main__':
     results_file = args.results
     # Logs
     logs = []
+
     def vprint(*args):
         for msg in args:
             logs.append(msg)

--- a/src/bin/composer-requirements.py
+++ b/src/bin/composer-requirements.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import json
-from os import path
 import sys
 
 
@@ -14,7 +13,8 @@ def merge_requirements(env_data, local_data):
 
     return local_data
 
-if __name__== "__main__":
+
+if __name__ == "__main__":
     if len(sys.argv) < 3:
         print('Argument are missing.\n Syntax: {0} <directory> <environment>'.format(sys.argv[0]))
         exit(1)

--- a/src/bin/composer-requirements.py
+++ b/src/bin/composer-requirements.py
@@ -10,10 +10,7 @@ COMPOSER_LOCAL = 'composer-local.json'
 def merge_requirements(env_data, local_data):
     env_require = env_data['require']
 
-    for package in env_require:
-        if package in local_data['require'].keys():
-            local_data['require'][package]=env_require[package]
-            print('Found {0}: Replacing with {1}'.format(package, env_require[package]))
+    local_data['require'].update(env_require)
 
     return local_data
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5946

---

Besides overriding existing dependencies, we could have a requirement we only want on one environment.

This has also an extra commit that uses `flake8` to have some basic (pep8) linting on python scripts. And fixed the existing issues.