### PR TITLE
PLANET-5946 Adjust scripts for single branch base repo

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,25 +20,16 @@ CONTAINER_PREFIX  ?= planet4-test
 
 # Configure composer source and merge repository data
 
-# Define APP_ENVIRONMENT because we need it in order to know what GIT_REF to use
+# Define APP_ENVIRONMENT in case it's not set to development already
 APP_ENVIRONMENT     ?= production
-
-# The branch to checkout of GIT_SOURCE, eg:
-# Use local branch name if not set
-
-ifeq ($(strip $(APP_ENVIRONMENT)),development)
-GIT_REF ?= develop
-else
-GIT_REF ?= master
-endif
 
 # Base composer project repository
 # FIXME change this to greenpeace/planet4-base once things are settled
-GIT_SOURCE        ?= https://github.com/greenpeace/planet4-base-fork
+GIT_SOURCE        ?= https://github.com/greenpeace/planet4-base
 
 # The branch to checkout of GIT_SOURCE, eg:
 # Use local branch name if not set
-GIT_REF           ?= develop
+GIT_REF           ?= main
 
 # Merge composer project directory (NRO)
 MERGE_SOURCE      ?= $(CIRCLE_REPOSITORY_URL)
@@ -77,7 +68,6 @@ ifeq ($(APP_HOSTPATH),<nil>)
 # So if APP_HOSTPATH is set, but blank, clean this value
 APP_HOSTPATH :=
 endif
-# APP_ENVIRONMENT     ?= production
 BUILD_NAMESPACE     ?= gcr.io
 GOOGLE_PROJECT_ID   ?= planet-4-151612
 NEWRELIC_APPNAME    ?= Greenpeace Planet4 Wordpress Test
@@ -102,8 +92,8 @@ PAGESPEED_ENABLED   ?= false
 
 INGRESS_CLASS				?= traefik
 
-ifeq ($(strip $(APP_ENVIRONMENT)),production)
 CLOUDFLARE_ENABLED  ?= true
+ifeq ($(strip $(APP_ENVIRONMENT)),production)
 MIN_REPLICA_COUNT 	?= 2
 else
 MIN_REPLICA_COUNT 	?= 1
@@ -185,6 +175,7 @@ checkout:
 	checkout.sh
 
 rewrite-app-repos:
+	composer-requirements.py "${HOME}/source/composer.json" "${APP_ENVIRONMENT}"
 	composer-requirements.py "${HOME}/merge/composer-local.json" "${APP_ENVIRONMENT}"
 	rewrite_app_repos.sh
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -185,7 +185,7 @@ checkout:
 	checkout.sh
 
 rewrite-app-repos:
-	composer-requirements.py "${HOME}/merge/" "${APP_ENVIRONMENT}"
+	composer-requirements.py "${HOME}/merge/composer-local.json" "${APP_ENVIRONMENT}"
 	rewrite_app_repos.sh
 
 rewrite:

--- a/src/bin/checkout.sh
+++ b/src/bin/checkout.sh
@@ -38,9 +38,13 @@ else
   git init
   git remote add origin "$GIT_SOURCE"
   git fetch
-  git reset "origin/${GIT_REF}"
+  if [ "$APP_ENVIRONMENT" == "production" ]; then
+    latest_tag=$(git-current-tag.sh)
+    git checkout "$latest_tag"
+  else
+    git reset "origin/${GIT_REF}"
+  fi
   git checkout -- .
-  # git clone "$GIT_SOURCE" .
 fi
 
 ls -al

--- a/src/bin/composer-requirements.py
+++ b/src/bin/composer-requirements.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 import json
+import os
 import sys
-
-
-COMPOSER_LOCAL = 'composer-local.json'
 
 
 def merge_requirements(env_data, local_data):
@@ -16,20 +14,21 @@ def merge_requirements(env_data, local_data):
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
-        print('Argument are missing.\n Syntax: {0} <directory> <environment>'.format(sys.argv[0]))
+        print('Argument are missing.\n Syntax: {0} <composer> <environment>'.format(sys.argv[0]))
         exit(1)
 
-    directory = sys.argv[1]
+    composer = sys.argv[1]
     environment = sys.argv[2]
+    directory = os.path.split(composer)[0]
 
     try:
-        env_file = open('{0}{1}.json'.format(directory, environment), 'r')
+        env_file = open('{0}/{1}.json'.format(directory, environment), 'r')
     except FileNotFoundError:
         print('No environment specific requirements')
         exit(0)
 
     try:
-        local_file = open('{0}{1}'.format(directory, COMPOSER_LOCAL), 'r')
+        local_file = open(composer, 'r')
     except FileNotFoundError:
         print('No local specific requirements')
         exit(0)
@@ -40,8 +39,11 @@ if __name__ == "__main__":
     local_file.close()
 
     merged_data = merge_requirements(env_data, local_data)
+    composer_final = json.dumps(merged_data, indent=4)
 
-    with open('{0}{1}'.format(directory, COMPOSER_LOCAL), 'w') as f:
-        f.write(json.dumps(merged_data, indent=4))
+    with open(composer, 'w') as f:
+        f.write(composer_final)
+
+    print(composer_final)
 
     exit(0)

--- a/src/bin/rewrite_dockerfiles.sh
+++ b/src/bin/rewrite_dockerfiles.sh
@@ -3,18 +3,6 @@ set -eu
 
 export SOURCE_PATH=/app/source
 
-# Specify which Dockerfile|README.md variables we want to change
-# shellcheck disable=SC2016
-# envvars=(
-#   '${PARENT_VERSION}' \
-#   '${GIT_REF}' \
-#   '${GIT_SOURCE}' \
-#   '${GOOGLE_PROJECT_ID}' \
-#   '${MAINTAINER}' \
-#   '${SOURCE_PATH}' \
-# )
-# envvars_string="$(printf "%s:" "${envvars[@]}")"
-
 for i in build app openresty; do
   build_dir=$i
   envsubst <"${build_dir}/Dockerfile.in" >"${build_dir}/Dockerfile"


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5946

---

Adjusted the composer script to be more generic. Instead of looking for `composer-local.json` we can can pass the full file
path as an argument. This way we can use the script for base repository requirements also.

---

Simplified Makefile scripts to use the latest tag when doing a production release (instead of master) and main branch when on
development (instead of develop). And also preparation for renaming the base repo, removing the fork suffix.
