### PR TITLE
Fix composer build

### DIFF
--- a/src/build/Dockerfile.in
+++ b/src/build/Dockerfile.in
@@ -24,7 +24,7 @@ RUN time composer -v install --no-dev --no-ansi --no-interaction --prefer-dist
 
 RUN \
     if [ -f "${SOURCE_PATH}/composer-local.json" ]; then \
-      rm -f composer.lock; \
+#      rm -f composer.lock; \
       time composer -v config --no-ansi extra.merge-plugin.require composer-local.json; \
     fi
 RUN time composer -v update --lock --no-dev --no-ansi --prefer-dist

--- a/src/build/Dockerfile.in
+++ b/src/build/Dockerfile.in
@@ -18,7 +18,7 @@ COPY . /app/
 
 WORKDIR /app/source
 
-RUN time composer -v update --lock --no-dev --no-ansi --prefer-dist
+#RUN time composer -v update --lock --no-dev --no-ansi --prefer-dist
 
 RUN time composer -v install --no-dev --no-ansi --no-interaction --prefer-dist
 


### PR DESCRIPTION
Composer started requiring a lock file to be present when running `update --lock`.

```dockerfile
Step 8/13 : RUN time composer -v update --lock --no-dev --no-ansi --prefer-dist
 ---> Running in aa6a23b36678
Cannot update lock file information without a lock file present. Run `composer update` to generate a lock file.

```

In our case the lock file is not there on the first command, which fails the build.
https://github.com/greenpeace/planet4-builder/blob/9ff87f94050375e4c72a68a369f062465598d657/src/build/Dockerfile.in#L21-L21

Then before running the second `update` (which is after `composer-local.json` was added), we were actually removing the lock file generated by the previous command. Again this fails the build with the same error.
https://github.com/greenpeace/planet4-builder/blob/9ff87f94050375e4c72a68a369f062465598d657/src/build/Dockerfile.in#L27-L27

Perhaps now is a good time to see why it did an update first and then an install. Then after configuring the local config file, it does both again. Could be it only needs to do the last of the 4 commands.

Though running the install of the base file separately first could actually be fast if the job can use cache for this. Not sure if that is the case now.