### PR TITLE
Remove --remote option

### DIFF
--- a/src/bin/rewrite_app_repos.sh
+++ b/src/bin/rewrite_app_repos.sh
@@ -28,8 +28,7 @@ build_assets() {
   if [ "$CIRCLE_PROJECT_REPONAME" == "$reponame" ] && [ -d "${checkoutDir}" ]; then
     mkdir -p "$reponame"
     cp -r "${checkoutDir}/." "$reponame"
-    git -C "$reponame" submodule init
-    git -C "$reponame" submodule update --remote
+    git -C "$reponame" submodule update --init
   else
     git clone --recurse-submodules --single-branch --branch "${branch}" https://github.com/greenpeace/"${reponame}"
   fi


### PR DESCRIPTION
It's [hidden in the docs](https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt---branchltbranchgt), but the `--remote` flag made it use the HEAD of the remote branch instead of the actual commit included in the current commit of the parent repo. Noticed it when the [paths changed here and it failed the assets build](https://app.circleci.com/pipelines/github/greenpeace/planet4-plugin-gutenberg-blocks/4065/workflows/8ea583ce-5434-4691-bbef-d63965916fbe/jobs/14386), while the assets build in the zip job of the same workflow did pass.

We probably didn't notice all this time because, except for acceptance tests, most workflows don't use branch versions so they don't have to build the assets.