### PR TITLE
PLANET-6020 Upgrade to composer 2

### DIFF
--- a/src/bin/rewrite_app_repos.sh
+++ b/src/bin/rewrite_app_repos.sh
@@ -68,14 +68,6 @@ for plugin_branch_env_var in "${plugin_branch_env_vars[@]}"; do
       tmp=$(mktemp)
       jq ".require.\"greenpeace/${reponame}\" = \"dev-${branch}\"" "$f" >"$tmp"
       mv "$tmp" "$f"
-
-      checkoutDir="/home/circleci/checkout/${reponame}"
-      # If builder is running for the theme or plugin, then we can use the checked out code of the current commit.
-      if [ "$CIRCLE_PROJECT_REPONAME" == "$reponame" ] && [ -d "${checkoutDir}" ]; then
-        tmp=$(mktemp)
-        jq ".repositories |= [{\"type\": \"path\", \"url\": \"${checkoutDir}\"}] + ." "$f" >"$tmp"
-        mv "$tmp" "$f"
-      fi
     done
 
     echo "And now, delete any cached version of this package"

--- a/src/build/Dockerfile.in
+++ b/src/build/Dockerfile.in
@@ -18,18 +18,14 @@ COPY . /app/
 
 WORKDIR /app/source
 
-RUN time composer -v update --lock --no-dev --no-ansi --prefer-dist
-
-RUN time composer -v install --no-dev --no-ansi --no-interaction --prefer-dist
+RUN time composer -v update --no-dev --no-ansi --prefer-dist
 
 RUN \
     if [ -f "${SOURCE_PATH}/composer-local.json" ]; then \
       rm -f composer.lock; \
       time composer -v config --no-ansi extra.merge-plugin.require composer-local.json; \
     fi
-RUN time composer -v update --lock --no-dev --no-ansi --prefer-dist
-
-RUN time composer -v install --no-dev --no-ansi --no-interaction --prefer-dist
+RUN time composer -v update --no-dev --no-ansi --prefer-dist
 
 RUN \
     if [ -d ${SOURCE_PATH}/built-dev-assets/ ]; then \


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6020

---

Two things changed here:
1. Removed `composer install` steps, since we have `composer update` in place. The base repo doesn't have a lock file, so I adjusted the update commands accordingly. This was fine with composer 1 but it breaks on 2.
2. Removed the check on whether we already are in a repo checkout. This was what it was breaking last time, complaining of folder being empty. Not sure why, but we can research that later if we want. It only costs us a few seconds to re-clone the repo.