### PR TITLE
Fetch zip file for tags to use composer's artifact type

### DIFF
--- a/src/bin/checkout.sh
+++ b/src/bin/checkout.sh
@@ -37,7 +37,7 @@ else
   cd /home/circleci/source
   git init
   git remote add origin "$GIT_SOURCE"
-  git fetch
+  git fetch --all --tags
   if [ "$APP_ENVIRONMENT" == "production" ]; then
     latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
     git checkout "$latest_tag"


### PR DESCRIPTION
Since we already detect tags at this step, besides skipping building the assets, we can also fetch the zip file from Github release already. We can then use [composer's artifact](https://getcomposer.org/doc/05-repositories.md#artifact) repository type in the next step to just install that zip from the local filesystem.

The only caveat of using artifacts is that `composer.json` file in that zip needs to have the proper version. To achieve that, we inject the version when we create the zip (see [https7c790e110b471e510de07e1d7218b96055440407](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/commit/7c790e110b471e510de07e1d7218b96055440407).

We need also to make sure test instances work with this, where we already use a different repository type (package). Since we use the version "7" convention, this adds an extra check to skip building assets but without trying to fectch a zip file; composer will take care of that in the next step.

### Testing

To test that in the CI, I'm using this branch on the [cidev instance](https://github.com/greenpeace/planet4-cidev/blob/main/.circleci/config.yml#L15). The [develop pipeline](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/1169/workflows/31cdb2a8-e2f4-4dcf-a641-aeccd8092f4d) gets the master branches, so everything works as expected. The [production pipeline](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/1170/workflows/55ca8ced-2839-490c-a910-b64ddadb04bb) got the tags with these changes and it works fine.

Opening the `make rewrite-app-repos` you can see:

```
Version v0.99 for planet4-plugin-gutenberg-blocks in /home/circleci/source/composer.json is not a branch, no need to build
Pulling the zip file
```

And opening `make bake` you can see that it install a tag using a local zip file.

```
Found package greenpeace/planet4-plugin-gutenberg-blocks (v0.99) in file planet4-plugin-gutenberg-blocks.zip
```