### PR TITLE
Ignore env file when requirements are missing

### DIFF
--- a/src/bin/composer-requirements.py
+++ b/src/bin/composer-requirements.py
@@ -5,7 +5,11 @@ import sys
 
 
 def merge_requirements(env_data, local_data):
-    env_require = env_data['require']
+    try:
+        env_require = env_data['require']
+    except KeyError:
+        print('No environment specific requirements')
+        exit(0)
 
     local_data['require'].update(env_require)
 


### PR DESCRIPTION
This is to catch an edge case where we do have an environment specific json file, but it's missing the require array.