### PR TITLE
Remove WP_VERSION fallback value

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - MYSQL_USER=${MYSQL_USER:-planet4}
       - OVERWRITE_EXISTING_FILES=true
       - WP_DEFAULT_CONTENT=false
-      - WP_VERSION=${WP_VERSION:-latest}
+      - WP_VERSION=${WP_VERSION}
     volumes:
       - type: volume
         source: data


### PR DESCRIPTION
If `WP_VERSION` is not defined as an env variable then leave it blank. This will allow us to fallback on the bare repo `wp-version` definition.