### PR TITLE
PLANET-6307 Adjust composer merge script to account for wp-version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.py]
+indent_size = 4
+
 [Makefile]
 indent_style = tab
 

--- a/src/bin/composer-requirements.py
+++ b/src/bin/composer-requirements.py
@@ -7,11 +7,18 @@ import sys
 def merge_requirements(env_data, local_data):
     try:
         env_require = env_data['require']
+        local_data['require'].update(env_require)
     except KeyError:
         print('No environment specific requirements')
-        exit(0)
 
-    local_data['require'].update(env_require)
+    try:
+        env_wp_version = env_data['extra']['wp-version']
+        try:
+            local_data['extra']['wp-version'] = env_wp_version
+        except KeyError:
+            local_data['extra'] = {'wp-version': env_wp_version}
+    except KeyError:
+        print('No environment specific wp version')
 
     return local_data
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6307

---

Additionally to merging composer requirements, the same script can also
merge `wp-version`. Same as before It works for both base and nro level
composer and environment files.