### PR TITLE
Faster update command for data sync to test instances

### DIFF
--- a/src/bin/sync_to_test_site.sh
+++ b/src/bin/sync_to_test_site.sh
@@ -89,12 +89,7 @@ $kc exec "${POD}" -- rm data.sql
 echo ""
 echo "Assign admin author to avoid orphan posts"
 echo ""
-$kc exec "${POD}" -- wp post list --post_type=post --field=ID --format=ids >posts.txt
-$kc exec "${POD}" -- wp post list --post_type=page --field=ID --format=ids >pages.txt
-$kc exec "${POD}" -- wp post list --post_type=campaign --field=ID --format=ids >campaigns.txt
-$kc exec "${POD}" -- bash -c "wp post update $(cat campaigns.txt) --post_author=1"
-$kc exec "${POD}" -- bash -c "wp post update $(cat pages.txt) --post_author=1"
-$kc exec "${POD}" -- bash -c "wp post update $(cat posts.txt) --post_author=1"
+$kc exec "${POD}" -- wp p4-post fix-orphans
 
 echo ""
 echo "Flushing cache"


### PR DESCRIPTION
Cf https://github.com/greenpeace/planet4-master-theme/pull/1527

Using a custom command for orphan posts update, to reduce execution time.

Sync from international:
- Before fix, 40 minutes https://app.circleci.com/pipelines/github/greenpeace/planet4-test-pandora/152/workflows/4096c607-bc6c-48b7-bda8-aa84c5ee3ed9/jobs/773
- After fix, 4 minutes https://app.circleci.com/pipelines/github/greenpeace/planet4-test-umbriel/70/workflows/98091edc-57fa-43d5-ad86-127811a02134/jobs/406