### PR TITLE
Use DEPLOYED revisions also for rollback

### DIFF
--- a/src/bin/helm_rollback.sh
+++ b/src/bin/helm_rollback.sh
@@ -29,7 +29,8 @@ echo "Release #current of $release is in state: $status"
 # Find last good deployment
 previous=${2:-$((current - 1))}
 while [[ $previous -gt 0 ]]; do
-  [[ $(helm status "$release" --revision "$previous" | grep '^STATUS:' | cut -d' ' -f2 | xargs) == "SUPERSEDED" ]] && break
+  revision_status=$(helm status "$release" --revision "$previous" | grep '^STATUS:' | cut -d' ' -f2 | xargs)
+  [[ "$revision_status" == "SUPERSEDED" || "$revision_status" == "DEPLOYED" ]] && break
   previous=$((previous - 1))
 done
 


### PR DESCRIPTION
Currently the rollback script only looks for `SUPERSEDED` revisions, which in cases of failed deployments will skip the last successfully deployed and go to the one before that.

Even in cases where the last revision is successfully deployed, but we do want to rollback, this still works since we use: `previous=${2:-$((current - 1))}` right before the look up loop.