### PR TITLE
Update helm chart to 0.8.20

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ PARENT_IMAGE      ?= gcr.io/planet-4-151612/wordpress
 PARENT_VERSION    ?= latest
 
 # Wordpress Helm chart version
-CHART_VERSION     ?= 0.8.19
+CHART_VERSION     ?= 0.8.20
 
 # Use current folder name as prefix for built containers,
 # eg planet4-gpi-app planet4-gpi-openresty


### PR DESCRIPTION
This update requires that https://github.com/greenpeace/planet4-helm-wordpress/pull/18 is merged and version 0.8.20 is tagged first. 
Then do the following:
1) Merge
2) Trigger dev redeployment - monitor
3) Rerun latest prod deployment - monitor