### PR TITLE
Add script to check data sync flag

### DIFF
--- a/src/bin/check-data-sync-flag.sh
+++ b/src/bin/check-data-sync-flag.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -ex
+
+GCLOUD_ZONE="us-central1-a"
+
+gcloud container clusters get-credentials "${GCLOUD_CLUSTER}" \
+  --zone "${GCLOUD_ZONE}" \
+  --project "${GOOGLE_PROJECT_ID}"
+
+php=$(kubectl get pods --namespace "${HELM_NAMESPACE}" \
+  --sort-by=.metadata.creationTimestamp \
+  --field-selector=status.phase=Running \
+  -l "release=${HELM_RELEASE},component=php" \
+  -o jsonpath="{.items[-1:].metadata.name}")
+
+if [[ -z "$php" ]]; then
+  echo "ERROR: PHP pod not found!"
+  exit 1
+fi
+
+SYNC_DISABLED_FLAG=$(kubectl --namespace "${HELM_NAMESPACE}" exec "$php" -- wp option pluck planet4_features disable_data_sync || true)
+
+if [[ $SYNC_DISABLED_FLAG == "on" ]]; then
+  echo "Data sync is disabled in Admin Panel"
+  exit 1
+fi


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6772

---

Added a `|| true` in the end since an empty option returns a failed exit status. It's more reliable to actually look for an `on` value on that flag.

### Testing

I used cidev to test this.
1. Changed the [builder tag](https://github.com/greenpeace/planet4-cidev/blob/af2743c9f24db22aebf2f244679f3404b286bdab/.circleci/config.yml#L15)  to use this branch.
2. Added this extra script on [sync-to-develop job](https://github.com/greenpeace/planet4-cidev/blob/af2743c9f24db22aebf2f244679f3404b286bdab/.circleci/config.yml#L422-L424).
3. I amended the [data sync workflow](https://github.com/greenpeace/planet4-cidev/blob/af2743c9f24db22aebf2f244679f3404b286bdab/.circleci/config.yml#L549-L569) to run for every commit on `main` branch.

Then I tested by toggling the flag on and off in the admin panel.

**Results**
1. By default (flag unchecked): [pipeline runs properly](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/1589/workflows/715e1f0b-864e-49af-8d83-a36e68f0128b/jobs/4087).
2. Disabling data sync (flag checked): [sync-to-develop job fails](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/1588/workflows/26ef426d-c6f5-43b0-b913-c130a5dd7029/jobs/4083).