### PR TITLE
fix: backup script was not fetching namespace properly

### DIFF
--- a/src/bin/backup_db.sh
+++ b/src/bin/backup_db.sh
@@ -17,7 +17,7 @@ echo "Release:   $release"
 echo "Tag:       $tag"
 echo
 
-namespace=$(helm3 list -A -o json | jq 'map(select(.name == "${HELM_RELEASE}")) | .[0].namespace')
+namespace=$(helm3 list -A -o json | jq --arg release "$release" 'map(select(.name == $release)) | .[0].namespace' | tr -d '"')
 
 if ! helm3 status -n "$namespace" "${HELM_RELEASE}" | tee release_status.txt; then
   echo "SKIP: Release not yet deployed"


### PR DESCRIPTION
Fixes issue raised by flo in the backup script on the builder image. The namespace was not being fetched properly so just required a small modification to the script to properly support helm3.