### PR TITLE
PLANET-6841 Exclude GF database tables from sync script

### DIFF
--- a/src/bin/sql_create_sync_file.sh
+++ b/src/bin/sql_create_sync_file.sh
@@ -34,6 +34,7 @@ echo ""
 echo "mysqldump ${WP_DB_NAME} > content/${WP_DB_NAME}-${SQL_TAG}.sql ..."
 echo ""
 mysqldump -v --column-statistics=0 --set-gtid-purged=OFF \
+  --ignore-table="$WP_DB_NAME".wp_gf_draft_submissions --ignore-table="$WP_DB_NAME".wp_gf_entry --ignore-table="$WP_DB_NAME".wp_gf_entry_meta --ignore-table="$WP_DB_NAME".wp_gf_entry_notes --ignore-table="$WP_DB_NAME".wp_gf_form --ignore-table="$WP_DB_NAME".wp_gf_form_meta --ignore-table="$WP_DB_NAME".wp_gf_form_revisions --ignore-table="$WP_DB_NAME".wp_gf_form_view \
   -u "$WP_DB_USERNAME_DC" \
   -p"$WP_DB_PASSWORD_DC" \
   -h 127.0.0.1 \


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6841

### Testing

I modified the export script in two different phases, and used a test instance to verify the dump. The regular `--ignore-tables` flag is being used, but unfortunately `mysqldump` doesn't support wildcards.

1. Full backup (same as the current script)
   - [Pipeline](https://app.circleci.com/pipelines/github/greenpeace/planet4-test-venus/353/workflows/72617024-97b9-43f4-9e29-1a5e4462293b/jobs/2051/steps)
   - On "Export DB" job the tables are listed in the `mysqldump` output.
   - In Artifacts the db dump can be downloaded and inspected with an editor that can handle big files (eg. vim 😁)

2. Back ignoring GF tables
   - [Pipeline](https://app.circleci.com/pipelines/github/greenpeace/planet4-test-venus/354/workflows/bcd32269-1b4f-4482-8e60-2834f3ea7b28/jobs/2092/steps)
   - On "Export DB" job the `wp_gf_` tables are missing from the `mysqldump` output.
   - In Artifacts the db dump can be downloaded and inspected. It contains no `wp-gf_` tables.