### PR TITLE
PLANET-6854: Disconnect Gravity Forms from external integrations on staging/dev sites

### DIFF
--- a/src/bin/sql_create_sync_file.sh
+++ b/src/bin/sql_create_sync_file.sh
@@ -34,7 +34,6 @@ echo ""
 echo "mysqldump ${WP_DB_NAME} > content/${WP_DB_NAME}-${SQL_TAG}.sql ..."
 echo ""
 mysqldump -v --column-statistics=0 --set-gtid-purged=OFF \
-  --ignore-table="$WP_DB_NAME".wp_gf_draft_submissions --ignore-table="$WP_DB_NAME".wp_gf_entry --ignore-table="$WP_DB_NAME".wp_gf_entry_meta --ignore-table="$WP_DB_NAME".wp_gf_entry_notes --ignore-table="$WP_DB_NAME".wp_gf_form --ignore-table="$WP_DB_NAME".wp_gf_form_meta --ignore-table="$WP_DB_NAME".wp_gf_form_revisions --ignore-table="$WP_DB_NAME".wp_gf_form_view \
   -u "$WP_DB_USERNAME_DC" \
   -p"$WP_DB_PASSWORD_DC" \
   -h 127.0.0.1 \

--- a/src/bin/sql_to_sync_site.sh
+++ b/src/bin/sql_to_sync_site.sh
@@ -142,6 +142,12 @@ echo "Discourage search engines from indexing dev/stage sites"
 echo
 $kc exec "$POD" -- wp option update blog_public 0
 
+if [[ "$APP_ENV" = "development" ]]; then
+  echo "Remove GF addons settings"
+  # shellcheck disable=SC2046
+  $kc exec "$POD" -- wp option delete $(wp option list --search='gravityformsaddon_*_settings' --field=option_name)
+fi
+
 echo ""
 echo "Flushing cache"
 echo ""

--- a/src/bin/sql_to_sync_site.sh
+++ b/src/bin/sql_to_sync_site.sh
@@ -142,11 +142,8 @@ echo "Discourage search engines from indexing dev/stage sites"
 echo
 $kc exec "$POD" -- wp option update blog_public 0
 
-if [[ "$APP_ENV" = "development" ]]; then
-  echo "Remove GF addons settings"
-  # shellcheck disable=SC2046
-  $kc exec "$POD" -- wp option delete $(wp option list --search='gravityformsaddon_*_settings' --field=option_name)
-fi
+echo "Remove GF addons authentication"
+$kc exec "$POD" -- wp p4-gf-addons disconnect
 
 echo ""
 echo "Flushing cache"


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6854
Uses: https://github.com/greenpeace/planet4-master-theme/pull/1777

Gravity forms addons have predictable settings option name, so we could remove those settings as shown [in the first commit](https://github.com/greenpeace/planet4-builder/commit/bf539e4a94b6c9e55d3bb11734ff879e5c3f7887)
```console
> wp option delete $(wp option list --search='gravityformsaddon_*_settings' --field=option_name)
```
but that might  remove more settings than necessary, as some settings only specify what is enabled or not.

The option taken here is to create a disconnect command in master-theme `wp p4-gf-addons disconnect` (easier to maintain) and use it here in the context of development/staging
