### PR TITLE
fix: enable namespace creation if ns doesn't exist

### DIFF
--- a/src/bin/helm_deploy.sh
+++ b/src/bin/helm_deploy.sh
@@ -11,6 +11,7 @@ function install() {
     --values "$HOME"/var/values.yaml \
     --values "$HOME"/var/secrets.yaml \
     --version "${CHART_VERSION}" \
+    --create-namespace \
     p4/wordpress 2>&1 | tee -a helm_output.txt; then
     echo "SUCCESS: Deployed release $HELM_RELEASE"
     return 0


### PR DESCRIPTION
This is some setup for moving the namespaces around in dev and staging. This was the default behaviour with Helm2 that was disabled with Helm3. Adding this command line switch re-enables it.