### PR TITLE
fix: bump helm chart

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ PARENT_IMAGE      ?= gcr.io/planet-4-151612/wordpress
 PARENT_VERSION    ?= latest
 
 # Wordpress Helm chart version
-CHART_VERSION     ?= 0.8.29
+CHART_VERSION     ?= 0.8.30
 
 # Use current folder name as prefix for built containers,
 # eg planet4-gpi-app planet4-gpi-openresty


### PR DESCRIPTION
This PR bumps the p4/wordpress helm chart. 

All sites will need to have the redis caching statefulset deleted and then allow the helm release to recreate it. This will not cause any outage because they are just used for caching and the sites work fine without them.

Process:
1. Merge this PR
2. Delete all dev statefulset
3. Run dev sites release
4. Delete all prod statefulsets
5. Run prod sites release
