### PR TITLE
Adjust test user creation to skip production sites.

### DIFF
--- a/src/bin/test_account_add.sh
+++ b/src/bin/test_account_add.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+if [ "$APP_ENVIRONMENT" = 'production' ]; then
+  echo "Production environment: skipping test user creation"
+  exit 0
+fi
+
 php=$(kubectl get pods --namespace "${HELM_NAMESPACE}" \
   --sort-by=.metadata.creationTimestamp \
   --field-selector=status.phase=Running \


### PR DESCRIPTION
This is just a precaution to make sure this script is not accidentally used in a production website, if we start using this script in more pipelines.